### PR TITLE
Store hydroData between runs for MCR - Improved MCR runtime

### DIFF
--- a/source/functions/wecSimMCR.m
+++ b/source/functions/wecSimMCR.m
@@ -64,9 +64,24 @@ else
     end
 end
 
+% Check to see if changing h5 file between runs
+% If one of the MCR headers is body(#).h5File, then the hydro data will be
+% loaded from the h5 file for each condition run. 
+reloadHydroDataFlag = true;
+if isempty(cell2mat(regexp(mcr.header, 'body\(\d+\).h5File')))
+    reloadHydroDataFlag = false;
+    clear hydroData
+end
+
 % Run WEC-Sim
 warning('off','MATLAB:DELETE:FileNotFound'); delete('mcrCase*.mat')
 for imcr=1:length(mcr.cases(:,1))
     wecSim;
     if exist('userDefinedFunctionsMCR.m','file') == 2; userDefinedFunctionsMCR; end
-end; clear imcr ans;
+    % Store hydrodata in memory for reuse in future runs.
+    if reloadHydroDataFlag == false && imcr == 1
+        for ii = 1:simu.numWecBodies 
+            hydroData(ii) = body(ii).hydroData;
+        end
+    end
+end; clear imcr ans hydroData reloadHydroDataFlag;

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -110,6 +110,15 @@ classdef bodyClass<handle
             try obj.hydroData.hydro_coeffs.radiation_damping.state_space.C.all = h5load(filename, [name '/hydro_coeffs/radiation_damping/state_space/C/all']); end
             try obj.hydroData.hydro_coeffs.radiation_damping.state_space.D.all = h5load(filename, [name '/hydro_coeffs/radiation_damping/state_space/D/all']); end
         end
+        
+        function loadHydroData(obj, hydroData)
+            % Loads hydroData structure from matlab variable as alternative
+            % to reading the h5 file. Used in wecSimMCR
+            obj.hydroData = hydroData;
+            obj.cg        = hydroData.properties.cg';
+            obj.dispVol   = hydroData.properties.disp_vol;
+            obj.name      = hydroData.properties.name;
+        end
 
         function hydroForcePre(obj,w,waveDir,CIkt,CTTime,numFreq,dt,rho,g,waveType,waveAmpTime,iBod,numBod,ssCalc,nlHydro,B2B)
             % HydroForce Pre-processing calculations

--- a/source/wecSim.m
+++ b/source/wecSim.m
@@ -31,9 +31,9 @@ evalc('wecSimInputFile');
 if exist('mcr','var') == 1; 
     for n=1:length(mcr.cases(1,:))
         if iscell(mcr.cases)
-            eval([mcr.header{n} '= mcr.cases{imcr,n}']);
+            eval([mcr.header{n} '= mcr.cases{imcr,n};']);
         else
-            eval([mcr.header{n} '= mcr.cases(imcr,n)']);
+            eval([mcr.header{n} '= mcr.cases(imcr,n);']);
         end
     end; clear n combine;
 end
@@ -75,10 +75,22 @@ for ii = 1:length(body(1,:))
         body(ii).massCalcMethod = 'user';
     end
 end
+% Determine if hydro data needs to be reloaded from h5 file, or if hydroData
+% was stored in memory from a previous run.
+readH5File = true;
+if exist('mcr','var') == 1
+    if reloadHydroDataFlag == false && imcr > 1
+        readH5File = false;
+    end
+end
 simu.numWecBodies = numHydroBodies; clear numHydroBodies
 for ii = 1:simu.numWecBodies
     body(ii).checkinputs;
-    body(ii).readH5File;
+    if readH5File == true
+        body(ii).readH5File;
+    else
+        body(ii).loadHydroData(hydroData(ii));
+    end
     body(ii).checkBemio;
     body(ii).bodyTotal = simu.numWecBodies;
     if simu.b2b==1
@@ -86,7 +98,7 @@ for ii = 1:simu.numWecBodies
     else
         body(ii).lenJ = zeros(6,1);
     end
-end; clear ii
+end; clear ii readH5File
 % PTO-Sim: read input, count
 if exist('./ptoSimInputFile.m','file') == 2 
     ptoSimInputFile 


### PR DESCRIPTION
Speed improvement for MCR:
* hydroData is stored in memory between uses to eliminate redundant h5 file read operations.
* Significantly improves overall MCR runtime when each case has a short runtime.
* if h5File is changed between runs, then hydroData is always reloaded from h5 file.

I have two test cases I can provide if requested.

See Issue https://github.com/WEC-Sim/WEC-Sim/issues/145 

@kmruehl 