### PR TITLE
Update bodyClass.m

### DIFF
--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -367,6 +367,8 @@ classdef bodyClass<handle
                 elseif obj.hydroData.simulation_parameters.wave_dir == waveDir
                     kernel = squeeze(kf(ii,1,:));
                     obj.userDefinedExcIRF = interp1(kt,kernel,min(kt):dt:max(kt));
+                else
+                    error('Default wave direction different from hydro database value. Wave direction should be specified on input file.')
                 end
                 obj.hydroForce.userDefinedFe(:,ii) = conv(waveAmpTime(:,2),obj.userDefinedExcIRF,'same')*dt;
             end


### PR DESCRIPTION
The change is related to 'user-defined' wave elevation cases. 

When 'length(obj.hydroData.simulation_parameters.wave_dir) == 1' BUT differs from the default waveDir=0 (elseif condition, line 367).
In those cases, the run would originally break since obj.userDefinedExcIRF is not produced.

Therefore, specifying the correct value in the wecSimInputFile.m fixes the problem.