### PR TITLE
Froude krylov and Diffraction body tag fix

### DIFF
--- a/source/functions/BEMIO/Read_AQWA.m
+++ b/source/functions/BEMIO/Read_AQWA.m
@@ -153,7 +153,7 @@ for ln=1:length(raw2);
         hydro(F).cb = [hydro(F).cb cb]; % Center of buoyancy
     
     elseif isempty(strfind(raw2{ln},'FROUDE KRYLOV + DIFFRACTION FORCES-VARIATION WITH WAVE PERIOD'))==0
-        k=str2num(raw2{ln-2}(end-8));                       % Body number flag
+        k=str2num(raw2{ln-2}(end-9:end-8));                       % Body number flag
         for j=1:hydro(F).Nh
             for i=1:hydro(F).Nf
                 tmp1 = str2num(raw2{ln+6+(j-1)*(hydro(F).Nf+9)+(i-1)});
@@ -175,7 +175,7 @@ for ln=1:length(raw2);
         
     elseif isempty(strfind(raw2{ln},'DIFFRACTION FORCES-VARIATION WITH WAVE PERIOD/FREQUENCY'))==0 ...
             && isempty(strfind(raw2{ln},'FROUDE KRYLOV +'))==1
-        kdiff=str2num(raw2{ln-2}(end-8));                       % Body number flag
+        kdiff=str2num(raw2{ln-2}(end-9:end-8));                       % Body number flag
         for j=1:hydro(F).Nh
             for i=1:hydro(F).Nf
                 tmp1 = str2num(raw2{ln+6+(j-1)*(hydro(F).Nf+9)+(i-1)});


### PR DESCRIPTION
The Read_AQWA function gives a matrix index error (the index is not a positive integer) when I try to model an array with more than 9 bodies. I found that the problem is with the 156th and 178th lines in the Read_AQWA function since they take only the (end-8)th character of the string which will be equal to 0 for structure number 10 and 1 for structure number 11 and so forth. This can be easily fixed by replacing (end-8) with (end-9:end-8) so as to capture the tens digit.