### PR TITLE
Improving help, and splitting out wave elevation calc to separate method

### DIFF
--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -150,7 +150,7 @@ classdef waveClass<handle
             %
             % Syntax
             %
-            % ws = waveClass (type)
+            % obj = waveClass (type)
             % 
             % Input
             %
@@ -176,7 +176,7 @@ classdef waveClass<handle
             %    
             % Output
             %
-            %  ws - wsim.waveSettings object
+            %  obj - waveClass object
             %
             %
             
@@ -465,11 +465,11 @@ classdef waveClass<handle
             %
             % Syntax
             %
-            % Z = waveElevationGrid (ws, t, X, Y)
+            % Z = waveElevationGrid (obj, t, X, Y)
             %
             % Input
             %
-            %  ws - wsim.waveSettings object
+            %  obj - waveClass object
             %
             %  t - the current time
             %


### PR DESCRIPTION
This PR does three things:

1. Converts the property help for all properties into the Matlab multi-line format, for example, property help for 'viz' now returns:

```
>> help waveClass.viz
  viz - Structure defining visualization options
    Should be a structure containing the fields 'numPointsX' and
    'numPointsY'. numPointsX is the number of visualization points
    in x direction, and numPointsY the number of visualization points
    in y direction
```
2. Adds help for the waveClass constructor, in the standard matlab help format, so now you can do:

```
>> help waveClass.waveClass
  waveClass constructor
 
  Syntax
 
  obj = waveClass (type)
  
  Input
 
   type - string containing the type of wave simulation to be
     generated, the possible values are
 
     'noWave' : no waves
 
     'noWaveCIC' : No waves but with the Convolution Integral 
       Calculation  to calculate radiation effects
 
     'regular' : Regular waves
 
     'regularCIC' : Regular waves with Convolution Integral 
       Calculation to calculate radiation effects
 
     'irregular' : Irregular Waves
 
     'spectrumImport' : Irregular Waves with predefined phase
 
     'etaImport' : Irregular Waves with predefined elevation
 
     
  Output
 
   obj - waveClass object

```
3. Splits out the calculation of wave elevations on a grid (from write_paraview_vtp) to a separate method as this is a generally useful thing to have access to.