### PR TITLE
Update responseClass.m - Add missing fclose(fid)

### DIFF
--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -114,6 +114,7 @@ classdef responseClass<handle
                     for icol=1:ncol
                         eval(['obj.moorDyn.Line' num2str(iline) '.' header{icol} ' = data(:,' num2str(icol) ');']);
                     end
+                    fclose(fid);
                 catch
                     fprintf('\n No moorDyn *.out file saved for Line%u\n',iline); 
                 end


### PR DESCRIPTION
When reading moorDyn outputs, each "LineX.out" file, the file is left open when reading. This can cause matlab to crash when repeatedly running models with moorDyn