### PR TITLE
Extended capabilities for Paraview visualization 

### DIFF
--- a/source/functions/paraViewVisualization.m
+++ b/source/functions/paraViewVisualization.m
@@ -27,7 +27,7 @@ if simu.paraview == 1
             error('The vtk directory could not be removed. Please close any files in the vtk directory and try running WEC-Sim again')
         end
     end
-    mkdir('vtk')
+    mkdir([simu.pathParaviewVideo,'\\vtk'])
     % check mooring
     moordynFlag = 0;
     if exist('mooring','var')
@@ -38,29 +38,38 @@ if simu.paraview == 1
         end
     end
     % bodies
-    filename = ['vtk' filesep 'bodies.txt'];
+    filename = [simu.pathParaviewVideo,'\\vtk' filesep 'bodies.txt'];
     fid = fopen(filename, 'w');
+    vtkbodiesii = 1;
     for ii = 1:length(body(1,:))
-        bodyname = output.bodies(ii).name;
-        mkdir(['vtk' filesep 'body' num2str(ii) '_' bodyname]);
-        body(ii).write_paraview_vtp(output.bodies(ii).time, output.bodies(ii).position, bodyname, simu.simMechanicsFile, datestr(simu.simulationDate), hspressure{ii}, wpressurenl{ii}, wpressurel{ii});
-        bodies{ii} = bodyname;
-        fprintf(fid,[bodyname '\n']);
-        fprintf(fid,[num2str(body(ii).viz.color) '\n']);
-        fprintf(fid,[num2str(body(ii).viz.opacity) '\n']);
-        fprintf(fid,'\n');
+        if body(ii).bodyparaview == 1
+            bodyname = output.bodies(ii).name;
+            mkdir([simu.pathParaviewVideo,'\\vtk' filesep 'body' num2str(vtkbodiesii) '_' bodyname]);
+            TimeBodyParav = output.bodies(ii).time;
+            PositionBodyParav = output.bodies(ii).position;
+            NewTimeParaview = simu.StartTimeParaview:simu.dtParaview:simu.EndTimeParaview;
+            PositionBodyParav = interp1(TimeBodyParav,PositionBodyParav,NewTimeParaview);
+            TimeBodyParav = NewTimeParaview-simu.StartTimeParaview;
+            body(ii).write_paraview_vtp(TimeBodyParav, PositionBodyParav, bodyname, simu.simMechanicsFile, datestr(simu.simulationDate), hspressure{ii}, wpressurenl{ii}, wpressurel{ii}, simu.pathParaviewVideo,vtkbodiesii);
+            bodies{vtkbodiesii} = bodyname;
+            fprintf(fid,[bodyname '\n']);
+            fprintf(fid,[num2str(body(vtkbodiesii).viz.color) '\n']);
+            fprintf(fid,[num2str(body(vtkbodiesii).viz.opacity) '\n']);
+            fprintf(fid,'\n');
+            vtkbodiesii = vtkbodiesii+1;
+        end
     end; clear ii
     fclose(fid);
     % waves
-    mkdir(['vtk' filesep 'waves'])
-    waves.write_paraview_vtp(output.bodies(1).time, waves.viz.numPointsX, waves.viz.numPointsY, simu.domainSize, simu.simMechanicsFile, datestr(simu.simulationDate),moordynFlag);
+    mkdir([simu.pathParaviewVideo,'\\vtk' filesep 'waves'])
+    waves.write_paraview_vtp(NewTimeParaview, waves.viz.numPointsX, waves.viz.numPointsY, simu.domainSize, simu.simMechanicsFile, datestr(simu.simulationDate),moordynFlag,simu.pathParaviewVideo,TimeBodyParav);
     % mooring
     if moordynFlag == 1
-        mkdir(['vtk' filesep 'mooring'])
-        mooring.write_paraview_vtp(output.moorDyn, simu.simMechanicsFile, output.bodies(1).time, datestr(simu.simulationDate), mooring.moorDynLines, mooring.moorDynNodes)
+        mkdir([simu.pathParaviewVideo,'\\vtk' filesep 'mooring'])
+        mooring.write_paraview_vtp(output.moorDyn, simu.simMechanicsFile, output.bodies(1).time, datestr(simu.simulationDate), mooring.moorDynLines, mooring.moorDynNodes,simu.pathParaviewVideo,TimeBodyParav,NewTimeParaview)
     end
     % all
-    output.write_paraview(bodies, output.bodies(1).time, simu.simMechanicsFile, datestr(simu.simulationDate), waves.type, moordynFlag);
+    output.write_paraview(bodies, TimeBodyParav, simu.simMechanicsFile, datestr(simu.simulationDate), waves.type, moordynFlag, simu.pathParaviewVideo);
     clear bodies fid filename
 end
 clear body*_hspressure_out body*_wavenonlinearpressure_out body*_wavelinearpressure_out  hspressure wpressurenl wpressurel cellareas bodyname 

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -49,6 +49,7 @@ classdef bodyClass<handle
         viz               = struct(...                                          % Structure defining visualization properties
             'color', [1 1 0], ...                            % Visualization color for either SimMechanics Explorer or Paraview.
             'opacity', 1)                                    % Visualization opacity for either SimMechanics Explorer or Paraview.
+        bodyparaview      = 0;                                                  % Visualisation in Paraview =1 otherwise =0.
         morisonElement   = struct(...                                          % Structure defining the Morrison Elements
             'cd',                 [0 0 0], ...               % Viscous (quadratic) drag cd, vector length 3
             'ca',                 [0 0 0], ...               % Added mass coefficent for Morrison Element (format [Ca_x Ca_y Ca_z], default = [0 0 0])
@@ -704,7 +705,7 @@ classdef bodyClass<handle
             verts_out(:,3) = verts(:,3) + x(3);
         end
         
-        function write_paraview_vtp(obj, t, pos_all, bodyname, model, simdate, hspressure,wavenonlinearpressure,wavelinearpressure)
+        function write_paraview_vtp(obj, t, pos_all, bodyname, model, simdate, hspressure,wavenonlinearpressure,wavelinearpressure,pathParaviewVideo,vtkbodiesii)
             % Writes vtp files for visualization with ParaView
             numVertex = obj.bodyGeometry.numVertex;
             numFace = obj.bodyGeometry.numFace;
@@ -719,7 +720,7 @@ classdef bodyClass<handle
                 vertex_mod = obj.rotateXYZ(vertex_mod,[0 0 1],pos(6));
                 vertex_mod = obj.offsetXYZ(vertex_mod,pos(1:3));
                 % open file
-                filename = ['vtk' filesep 'body' num2str(obj.bodyNumber) '_' bodyname filesep bodyname '_' num2str(it) '.vtp'];
+                filename = [pathParaviewVideo,filesep,'vtk' filesep 'body' num2str(vtkbodiesii) '_' bodyname filesep bodyname '_' num2str(it) '.vtp'];
                 fid = fopen(filename, 'w');
                 % write header
                 fprintf(fid, '<?xml version="1.0"?>\n');

--- a/source/objects/mooringClass.m
+++ b/source/objects/mooringClass.m
@@ -98,9 +98,21 @@ classdef mooringClass<handle
             fprintf('\n\t***** Mooring Name: %s *****\n',obj.name)
         end
 
-        function write_paraview_vtp(obj,moorDyn, model,t,simdate,nline,nnode)
+        function write_paraview_vtp(obj,moorDyn, model,t,simdate,nline,nnode,pathParaviewVideo,TimeBodyParav,NewTimeParaview)
             nsegment = nnode -1;
-            for it = 1:length(t)
+            for iline = 1:nline
+                for inode = 0:nnode(iline)-1
+                    moorDyn.(['Line' num2str(iline)]).(['Node' num2str(inode) 'px']) = interp1(t,moorDyn.(['Line' num2str(iline)]).(['Node' num2str(inode) 'px'])(:),NewTimeParaview);
+                    moorDyn.(['Line' num2str(iline)]).(['Node' num2str(inode) 'py']) = interp1(t,moorDyn.(['Line' num2str(iline)]).(['Node' num2str(inode) 'py'])(:),NewTimeParaview);
+                    moorDyn.(['Line' num2str(iline)]).(['Node' num2str(inode) 'pz']) = interp1(t,moorDyn.(['Line' num2str(iline)]).(['Node' num2str(inode) 'pz'])(:),NewTimeParaview);
+                end 
+            end          
+            for iline = 1:nline
+                for isegment = 0:nsegment(iline)-1
+                    moorDyn.(['Line' num2str(iline)]).(['Seg' num2str(isegment) 'Te']) = interp1(t,moorDyn.(['Line' num2str(iline)]).(['Seg' num2str(isegment) 'Te'])(:),NewTimeParaview);
+                end 
+            end
+            for it = 1:length(TimeBodyParav)
                 % open file
                 filename = ['vtk' filesep 'mooring' filesep 'mooring_' num2str(it) '.vtp'];
                 fid = fopen(filename, 'w');
@@ -109,7 +121,7 @@ classdef mooringClass<handle
                 fprintf(fid, ['<!-- WEC-Sim Visualization using ParaView -->\n']);
                 fprintf(fid, ['<!--   model: ' model ' - ran on ' simdate ' -->\n']);
                 fprintf(fid, ['<!--   mooring:  MoorDyn -->\n']);
-                fprintf(fid, ['<!--   time:  ' num2str(t(it)) ' -->\n']);
+                fprintf(fid, ['<!--   time:  ' num2str(TimeBodyParav(it)) ' -->\n']);
                 fprintf(fid, '<VTKFile type="PolyData" version="0.1">\n');
                 fprintf(fid, '  <PolyData>\n');
                 % write line info

--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -450,7 +450,7 @@ classdef responseClass<handle
             end 
         end
 
-        function write_paraview(obj, bodies, t, model, simdate, wavetype, mooring)
+        function write_paraview(obj, bodies, t, model, simdate, wavetype, mooring, pathParaviewVideo)
             % Writes vtp files for visualization with ParaView
             % set fileseperator to fs
             if strcmp(filesep, '\')
@@ -459,7 +459,7 @@ classdef responseClass<handle
                 fs = filesep;
             end
             % open file
-            fid = fopen(['vtk' fs model(1:end-4) '.pvd'], 'w');
+            fid = fopen([pathParaviewVideo,'\\vtk' fs model(1:end-4) '.pvd'], 'w');
             % write header
             fprintf(fid, '<?xml version="1.0"?>\n');
             fprintf(fid, ['<!-- WEC-Sim Visualization using ParaView -->\n']);

--- a/source/objects/simulationClass.m
+++ b/source/objects/simulationClass.m
@@ -46,6 +46,10 @@ classdef simulationClass<handle
         yawThresh           = 1                                            % Yaw position threshold (in degrees) above which excitation coefficients will be interpolated
         b2b                 = 0                                            % Option for body2body interactions: off->'0', on->'1', (default = 0)
         paraview            = 0                                            % Option for writing vtp files for paraview visualization.
+        StartTimeParaview  = 0;                                            % Start time for the vtk file of Paraview.                                    
+        EndTimeParaview  = 100;                                            % End time for the vtk file of Paraview.                                      
+        dtParaview = 0.1;                                                  % Timestep for Paraview.         
+        pathParaviewVideo = '';                                            % Path of the folder for Paraview vtk files.     
         adjMassWeightFun    = 2                                            % Weighting function for adjusting added mass term in the translational direction (default = 2)
         mcrCaseFile         = []                                           % mat file that contain a list of the multiple conditions runs with given conditions  
         morisonElement     = 0                                             % Option for Morrison Element calculation: Off->'0', On->'1', (default = 0)

--- a/source/wecSim.m
+++ b/source/wecSim.m
@@ -222,10 +222,10 @@ sv_stateSpace=Simulink.Variant('radiation_option==3');
 % Wave type
 typeNum = waves.typeNum;
 sv_noWave=Simulink.Variant('typeNum<10');
-sv_regularWaves=Simulink.Variant('typeNum>=10 && typeNum<20 && simu.yawNonLin~=1');
-sv_regularWavesNonLinYaw=Simulink.Variant('typeNum>=10 && typeNum<20 && simu.yawNonLin==1');
-sv_irregularWaves=Simulink.Variant('typeNum>=20 && typeNum<30 && simu.yawNonLin~=1');
-sv_irregularWavesNonLinYaw=Simulink.Variant('typeNum>=20 && typeNum<30 && simu.yawNonLin==1');
+sv_regularWaves=Simulink.Variant('typeNum>=10 && typeNum<20 && yawNonLin~=1');
+sv_regularWavesNonLinYaw=Simulink.Variant('typeNum>=10 && typeNum<20 && yawNonLin==1');
+sv_irregularWaves=Simulink.Variant('typeNum>=20 && typeNum<30 && yawNonLin~=1');
+sv_irregularWavesNonLinYaw=Simulink.Variant('typeNum>=20 && typeNum<30 && yawNonLin==1');
 sv_udfWaves=Simulink.Variant('typeNum>=30');
 % Body2Body
 B2B = simu.b2b;


### PR DESCRIPTION
Hi,
I have added the followings things regarding the Paraview visualization:
-Simulation options to decide the start-end time, timestep and path of the folder for Paraview.
-Option to decide which visualization bodies to have in Paraview.
-Option to visualize multi-directional waves for irregular waves and an imported wave elevation.
All these have been tested. However the Moordyn option visualization is still not tested and it is just a draft.
It is used an interpolation method to know the position of the bodies with the simulated time for Paraview. Let me know if it can be useful.