### PR TITLE
Redirect to \examples\BEMIO\ and small typos

### DIFF
--- a/source/functions/BEMIO/Combine_BEM.m
+++ b/source/functions/BEMIO/Combine_BEM.m
@@ -9,7 +9,7 @@ function hydro = Combine_BEM(hydro)
 % hydro = Combine_BEM(hydro)
 %     hydro – data structure
 %
-% See ‘…\WEC-Sim\tutorials\BEMIO\NEMOH\...’ for examples of usage.
+% See ‘...WEC-Sim\examples\BEMIO\NEMOH...’ for examples of usage.
 
 p = waitbar(0,'Combining multiple BEM results...');  % Progress bar
 

--- a/source/functions/BEMIO/Excitation_IRF.m
+++ b/source/functions/BEMIO/Excitation_IRF.m
@@ -15,7 +15,7 @@ function hydro = Excitation_IRF(hydro,t_end,n_t,n_w,w_min,w_max)
 %             the maximum frequency from the BEM data.
 % 
 % Default values are indicated by [].
-% See ‘…\WEC-Sim\tutorials\BEMIO\...’ for examples of usage.
+% See ‘...WEC-Sim\examples\BEMIO...’ for examples of usage.
 
 p = waitbar(0,'Calculating excitation IRFs...');  % Progress bar
 

--- a/source/functions/BEMIO/Plot_BEMIO.m
+++ b/source/functions/BEMIO/Plot_BEMIO.m
@@ -5,7 +5,7 @@ function Plot_BEMIO(hydro)
 % Plot_BEMIO(hydro)
 %     hydro – data structure
 % 
-% See ‘…\WEC-Sim\tutorials\BEMIO\...’ for examples of usage.
+% See ‘...WEC-Sim\examples\BEMIO...’ for examples of usage.
 
 p = waitbar(0,'Plotting BEMIO results…');  % Progress bar
 

--- a/source/functions/BEMIO/Radiation_IRF.m
+++ b/source/functions/BEMIO/Radiation_IRF.m
@@ -15,7 +15,7 @@ function hydro = Radiation_IRF(hydro,t_end,n_t,n_w,w_min,w_max)
 %             the maximum frequency from the BEM data
 % 
 % Default values are indicated by [].
-% See ‘…\WEC-Sim\tutorials\BEMIO\...’ for examples of usage.
+% See ‘...WEC-Sim\examples\BEMIO...’ for examples of usage.
 
 p = waitbar(0,'Calculating radiation IRFs...');  % Progress bar
 

--- a/source/functions/BEMIO/Radiation_IRF_SS.m
+++ b/source/functions/BEMIO/Radiation_IRF_SS.m
@@ -10,7 +10,7 @@ function hydro = Radiation_IRF_SS(hydro,Omax,R2t)
 %             where R2R2 may range from 0 to 1, and the default is 0.95
 % 
 % Default values are indicated by [].
-% See ‘…\WEC-Sim\tutorials\BEMIO\...’ for examples of usage.
+% See ‘...WEC-Sim\examples\BEMIO...’ for examples of usage.
 
 p = waitbar(0,'Calculating state space radiation IRFs...');  % Progress bar
 

--- a/source/functions/BEMIO/Read_AQWA.m
+++ b/source/functions/BEMIO/Read_AQWA.m
@@ -7,7 +7,7 @@ function hydro = Read_AQWA(hydro,ah1_filename,lis_filename)
 %     ah1_filename -  .AH1 AQWA output file
 %     lis_filename -  .LIS AQWA output file
 %
-% See '\\WEC-Sim\tutorials\BEMIO\AQWA\...' for examples of usage.
+% See '...WEC-Sim\examples\BEMIO\AQWA...' for examples of usage.
 
 %%
 

--- a/source/functions/BEMIO/Read_NEMOH.m
+++ b/source/functions/BEMIO/Read_NEMOH.m
@@ -14,7 +14,7 @@ function hydro = Read_NEMOH(hydro,filedir)
 %         - Results/DiffractionForce.tec - If simu.nlHydro = 3 will be used
 %         - Results/FKForce.tec - If simu.nlHydro = 3 will be used
 %
-% See '\\WEC-Sim\tutorials\BEMIO\NEMOH\...' for examples of usage.
+% See '...WEC-Sim\examples\BEMIO\NEMOH...' for examples of usage.
 
 %% Check filedir for required directories
 % NOTE: reads upper and lower case directories

--- a/source/functions/BEMIO/Read_WAMIT.m
+++ b/source/functions/BEMIO/Read_WAMIT.m
@@ -8,7 +8,7 @@ function hydro = Read_WAMIT(hydro,filename,ex_coeff)
 %     ex_coeff -  flag indicating the type of excitation force coefficients
 %                 to read, ‘diffraction’ (default, []), ‘haskind’, or ‘rao’
 %
-% See ‘\\WEC-Sim\tutorials\BEMIO\WAMIT\...’ for examples of usage.
+% See ‘...WEC-Sim\examples\BEMIO\WAMIT...’ for examples of usage.
 % Note: If generalized body modes are used, the output directory must also
 % include the *.cfg, *.mmx, and *.hst files. And, if simu.nlHydro = 3 will 
 % be used, the output directory must also include the .3fk and .3sc files.

--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -289,8 +289,8 @@ classdef responseClass<handle
                 t,FLD)
             legend('forceTotal','forceExcitation','forceRadiationDamping','forceAddedMass','forceRestoring','forceViscous','forceLinearDamping')
             xlabel('Time (s)')
-            ylabel('Force(N) or Torque (N*m)')
-            title(['body' num2str(bodyNum) ' (' obj.bodies(bodyNum).name ') ' DOF{comp} '  Forces'])
+            ylabel('Force (N) or Torque (N*m)')
+            title(['body' num2str(bodyNum) ' (' obj.bodies(bodyNum).name ') ' DOF{comp} ' Forces'])
 
             clear t FT FE FRD FR FV FM i
         end

--- a/source/objects/simulationClass.m
+++ b/source/objects/simulationClass.m
@@ -149,7 +149,7 @@ classdef simulationClass<handle
             end            
             % Check simMechanics file exists
             if exist(obj.simMechanicsFile,'file') ~= 4
-                error('The simMecahnics file, %s, does not exist in the case directory',value)
+                error('The simMechanics file, %s, does not exist in the case directory',value)
             end
             % Remove existing output folder
             if exist(obj.outputDir,'dir') ~= 0

--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -149,10 +149,10 @@ classdef waveClass<handle
             if nargin==2
                 hold on
                 line([rampTime,rampTime],[1.5*min(obj.waveAmpTime(:,2)),1.5*max(obj.waveAmpTime(:,2))],'Color','k')
-                title(['Wave Surfave Elevation, Ramp Time ' num2str(rampTime) ' (s)'])
+                title(['Wave Surface Elevation, Ramp Time ' num2str(rampTime) ' (s)'])
             end
             xlabel('Time (s)')
-            ylabel('Eta (m)')
+            ylabel('Elevation (m)')
         end
         
         function plotSpectrum(obj)

--- a/tutorials/OSWEC/hydroData/README.md
+++ b/tutorials/OSWEC/hydroData/README.md
@@ -1,0 +1,1 @@
+The WAMIT run used to generate this OSWEC hydroData is available here: [WEC-Sim\examples\BEMIO\WAMIT\OSWEC](https://github.com/WEC-Sim/WEC-Sim/tree/master/examples/BEMIO/WAMIT/OSWEC).

--- a/tutorials/OSWEC/hydroData/README.txt
+++ b/tutorials/OSWEC/hydroData/README.txt
@@ -1,2 +1,0 @@
-OSWEC WAMIT files available here:
-WEC-Sim\examples\BEMIO\WAMIT\OSWEC

--- a/tutorials/OSWEC/hydroData/README.txt
+++ b/tutorials/OSWEC/hydroData/README.txt
@@ -1,2 +1,2 @@
 OSWEC WAMIT files available here:
-WEC-Sim\tutorials\BEMIO\WAMIT\OSWEC
+WEC-Sim\examples\BEMIO\WAMIT\OSWEC

--- a/tutorials/RM3/hydroData/README.md
+++ b/tutorials/RM3/hydroData/README.md
@@ -1,0 +1,1 @@
+The WAMIT run used to generate this RM3 hydroData is available here: [WEC-Sim\examples\BEMIO\WAMIT\RM3](https://github.com/WEC-Sim/WEC-Sim/tree/master/examples/BEMIO/WAMIT/RM3).

--- a/tutorials/RM3/hydroData/README.txt
+++ b/tutorials/RM3/hydroData/README.txt
@@ -1,2 +1,0 @@
-RM3 WAMIT files available here:
-WEC-Sim\examples\BEMIO\WAMIT\RM3

--- a/tutorials/RM3/hydroData/README.txt
+++ b/tutorials/RM3/hydroData/README.txt
@@ -1,2 +1,2 @@
 RM3 WAMIT files available here:
-WEC-Sim\tutorials\BEMIO\WAMIT\RM3
+WEC-Sim\examples\BEMIO\WAMIT\RM3


### PR DESCRIPTION
Redirect old files from WEC-Sim\tutorials\BEMIO to WEC-Sim\examples\BEMIO
Fixed some small typos