### PR TITLE
bugfixes for paraview

### DIFF
--- a/source/functions/paraViewVisualization.m
+++ b/source/functions/paraViewVisualization.m
@@ -39,7 +39,9 @@ if simu.paraview == 1
     end
    % bodies
     filename = [simu.pathParaviewVideo,'\\vtk' filesep 'bodies.txt'];
-    fid = fopen(filename, 'w');
+    %fid = fopen(filename, 'w');
+    mkdir([simu.pathParaviewVideo filesep 'vtk'])
+    [fid ,errmsg] = fopen(filename, 'w');
     vtkbodiesii = 1;
     for ii = 1:length(body(1,:))
         if body(ii).bodyparaview == 1

--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -418,9 +418,9 @@ classdef waveClass<handle
             clear  numPoints numVertex numFace x y lx ly X Y Z fid filename p1 p2 p3 p4
     end
         
-        function Z = waveElevationGrid(obj, t, X, Y)
+        function Z = waveElevationGrid(obj, t, X, Y, TimeBodyParav, it, g)
             % This method calculates wave elevation on a grid at a given
-            % time, used by: :meth:`waveClass.write_paraview_vtp`.
+            % time, used by: :math:`waveClass.write_paraview_vtp`.
             %             
             % Parameters
             % ------------


### PR DESCRIPTION
create folder before creating 'bodies.txt' file  to avoid "No such file or directory" on fopen() call on windows
use correct arity when calling waveElevationGrid()