### PR TITLE
WEC-Sim output to a MATLAB structure

### DIFF
--- a/source/objects/simulationClass.m
+++ b/source/objects/simulationClass.m
@@ -53,7 +53,8 @@ classdef simulationClass<handle
         adjMassWeightFun    = 2                                            % (`integer`) Weighting function for adjusting added mass term in the translational direction. Default = ``2``
         mcrCaseFile         = []                                           % (`string`) mat file that contain a list of the multiple conditions runs with given conditions. Default = ``'NOT DEFINED'``  
         morisonElement     = 0                                             % (`integer`) Option for Morrison Element calculation: off->0, on->1. Default = ``0``
-        outputtxt           = 0                                            % (`integer`) Option to save results as ASCII files off->0, on->1. Default = ``0``
+        outputtxt           = 0                                            % (`integer`) Option to save results as ASCII files: off->0, on->1. Default = ``0``
+        outputStructure     = 0                                            % (`integer`) Option to save results as a MATLAB structure: off->0, on->1. Default = ``0``
         reloadH5Data        = 0                                            % (`integer`) Option to re-load hydro data from hf5 file between runs: off->0, on->1. Default = ``0``
         saveMat             = 1                                            % (`integer`) Option to save .mat file for each run: off->0, on->1. Default = ``1``
         pressureDis         = 0                                            % (`integer`) Option to save pressure distribution: off->0, on->1. Default = ``0``

--- a/source/wecSim.m
+++ b/source/wecSim.m
@@ -306,13 +306,16 @@ end
 if simu.outputtxt==1
     output.writetxt();
 end
+if simu.outputStructure==1
+    output = struct(output);
+end
+
 paraViewVisualization
 
 %% Save files
 clear ans table tout;
 toc
 diary off
-%movefile('simulation.log',simu.logFile)
 if simu.saveMat==1
     save(simu.caseFile,'-v7.3')
 end


### PR DESCRIPTION
Added a `simulationClass` property flag that saves the WEC-Sim output object to a structure, e.g. `output = struct(output);`. This is necessary for use by MHKiT (and python in general), as demonstrated by the [MHKiT WEC-Sim Example](https://mhkit-software.github.io/MHKiT/wecsim_example.html). This is feature is initialized in the `wecSimInputFile.m` by specifying `simu.outputStructure = 1;`

![image](https://user-images.githubusercontent.com/4603379/95634804-fb4cc400-0a47-11eb-9e2d-297a685f5cba.png)

**NOTE: I requested a merge with master as this is needed by MHKiT now** @ssolson and @rpauly18
