### PR TITLE
Paraview pressure fix

### DIFF
--- a/source/functions/paraViewVisualization.m
+++ b/source/functions/paraViewVisualization.m
@@ -50,7 +50,8 @@ if simu.paraview == 1
             NewTimeParaview(:,1) = simu.StartTimeParaview:simu.dtParaview:simu.EndTimeParaview;
             PositionBodyParav = interp1(TimeBodyParav,PositionBodyParav,NewTimeParaview);
             TimeBodyParav = NewTimeParaview-simu.StartTimeParaview;
-            body(ii).write_paraview_vtp(TimeBodyParav, PositionBodyParav, bodyname, simu.simMechanicsFile, datestr(simu.simulationDate), hspressure{ii}, wpressurenl{ii}, wpressurel{ii}, simu.pathParaviewVideo,vtkbodiesii);
+%             body(ii).write_paraview_vtp(TimeBodyParav, PositionBodyParav, bodyname, simu.simMechanicsFile, datestr(simu.simulationDate), hspressure{ii}, wpressurenl{ii}, wpressurel{ii}, simu.pathParaviewVideo,vtkbodiesii);
+            body(ii).write_paraview_vtp(TimeBodyParav, PositionBodyParav, bodyname, simu.simMechanicsFile, datestr(simu.simulationDate), output.bodies(ii).cellPressures_hydrostatic, output.bodies(ii).cellPressures_waveNonLinear, output.bodies(ii).cellPressures_waveLinear, simu.pathParaviewVideo,vtkbodiesii);
             bodies{vtkbodiesii} = bodyname;
             fprintf(fid,[bodyname '\n']);
             fprintf(fid,[num2str(body(vtkbodiesii).viz.color) '\n']);

--- a/source/functions/paraViewVisualization.m
+++ b/source/functions/paraViewVisualization.m
@@ -37,14 +37,14 @@ if simu.paraview == 1
         end
     end
    % bodies
-    filename = [simu.pathParaviewVideo filesep 'vtk' filesep 'bodies.txt'];
-    mkdir([simu.pathParaviewVideo filesep 'vtk'])
+    filename = [simu.pathParaviewVideo filesep 'bodies.txt'];
+    mkdir([simu.pathParaviewVideo])
     [fid ,errmsg] = fopen(filename, 'w');
     vtkbodiesii = 1;
     for ii = 1:length(body(1,:))
         if body(ii).bodyparaview == 1
             bodyname = output.bodies(ii).name;
-            mkdir([simu.pathParaviewVideo filesep 'vtk' filesep 'body' num2str(vtkbodiesii) '_' bodyname]);
+            mkdir([simu.pathParaviewVideo filesep 'body' num2str(vtkbodiesii) '_' bodyname]);
             TimeBodyParav = output.bodies(ii).time;
             PositionBodyParav = output.bodies(ii).position;
             NewTimeParaview(:,1) = simu.StartTimeParaview:simu.dtParaview:simu.EndTimeParaview;
@@ -61,11 +61,11 @@ if simu.paraview == 1
     end; clear ii
     fclose(fid);
     % waves
-       mkdir([simu.pathParaviewVideo filesep 'vtk' filesep 'waves'])
+       mkdir([simu.pathParaviewVideo filesep 'waves'])
         waves.write_paraview_vtp(NewTimeParaview, waves.viz.numPointsX, waves.viz.numPointsY, simu.domainSize, simu.simMechanicsFile, datestr(simu.simulationDate),moordynFlag,simu.pathParaviewVideo,TimeBodyParav, simu.g);    % mooring
     % mooring
     if moordynFlag == 1
-        mkdir([simu.pathParaviewVideo filesep 'vtk' filesep 'mooring'])
+        mkdir([simu.pathParaviewVideo filesep 'mooring'])
         mooring.write_paraview_vtp(output.moorDyn, simu.simMechanicsFile, output.moorDyn.Lines.Time, datestr(simu.simulationDate), mooring.moorDynLines, mooring.moorDynNodes,simu.pathParaviewVideo,TimeBodyParav,NewTimeParaview)
     end
     % all

--- a/source/functions/paraViewVisualization.m
+++ b/source/functions/paraViewVisualization.m
@@ -50,7 +50,6 @@ if simu.paraview == 1
             NewTimeParaview(:,1) = simu.StartTimeParaview:simu.dtParaview:simu.EndTimeParaview;
             PositionBodyParav = interp1(TimeBodyParav,PositionBodyParav,NewTimeParaview);
             TimeBodyParav = NewTimeParaview-simu.StartTimeParaview;
-%             body(ii).write_paraview_vtp(TimeBodyParav, PositionBodyParav, bodyname, simu.simMechanicsFile, datestr(simu.simulationDate), hspressure{ii}, wpressurenl{ii}, wpressurel{ii}, simu.pathParaviewVideo,vtkbodiesii);
             body(ii).write_paraview_vtp(TimeBodyParav, PositionBodyParav, bodyname, simu.simMechanicsFile, datestr(simu.simulationDate), output.bodies(ii).cellPressures_hydrostatic, output.bodies(ii).cellPressures_waveNonLinear, output.bodies(ii).cellPressures_waveLinear, simu.pathParaviewVideo,vtkbodiesii);
             bodies{vtkbodiesii} = bodyname;
             fprintf(fid,[bodyname '\n']);

--- a/source/functions/postProcess.m
+++ b/source/functions/postProcess.m
@@ -37,7 +37,7 @@ for iBod = 1:length(body(1,:))
         eval(['bodiesOutput(' num2str(iBod) ').wpressurel = body' num2str(iBod) '_wavelinearpressure_out;']);
     else
         if simu.nlHydro==0 && simu.pressureDis == 1 
-            warning('pressure distribution on the body (simu.pressureDis == 1) can only be output when wecSim is run with non-linear hydro (simu.nlHydro~=0)')
+            warning('Pressure distribution on the body is only output when wecSim is run with non-linear hydro (simu.pressureDis == 1 && simu.nlHydro~=0 && body(i).nhBody==0)')
         end
         bodiesOutput(iBod).hspressure = [];
         bodiesOutput(iBod).wpressurenl = [];

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -799,7 +799,6 @@ classdef bodyClass<handle
                 if ~isempty(hspressure)
                     fprintf(fid,'        <DataArray type="Float32" Name="Hydrostatic Pressure" NumberOfComponents="1" format="ascii">\n');
                     for ii = 1:numFace
-%                         fprintf(fid, '          %i', hspressure.signals.values(it,ii));
                         fprintf(fid, '          %i', hspressure(it,ii));
                     end
                     fprintf(fid, '\n');
@@ -809,7 +808,6 @@ classdef bodyClass<handle
                 if ~isempty(wavenonlinearpressure)
                     fprintf(fid,'        <DataArray type="Float32" Name="Wave Pressure NonLinear" NumberOfComponents="1" format="ascii">\n');
                     for ii = 1:numFace
-%                         fprintf(fid, '          %i', wavenonlinearpressure.signals.values(it,ii));
                         fprintf(fid, '          %i', wavenonlinearpressure(it,ii));
                     end
                     fprintf(fid, '\n');
@@ -819,7 +817,6 @@ classdef bodyClass<handle
                 if ~isempty(wavelinearpressure)
                     fprintf(fid,'        <DataArray type="Float32" Name="Wave Pressure Linear" NumberOfComponents="1" format="ascii">\n');
                     for ii = 1:numFace
-%                         fprintf(fid, '          %i', wavelinearpressure.signals.values(it,ii));
                         fprintf(fid, '          %i', wavelinearpressure(it,ii));
                     end
                     fprintf(fid, '\n');

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -799,7 +799,8 @@ classdef bodyClass<handle
                 if ~isempty(hspressure)
                     fprintf(fid,'        <DataArray type="Float32" Name="Hydrostatic Pressure" NumberOfComponents="1" format="ascii">\n');
                     for ii = 1:numFace
-                        fprintf(fid, '          %i', hspressure.signals.values(it,ii));
+%                         fprintf(fid, '          %i', hspressure.signals.values(it,ii));
+                        fprintf(fid, '          %i', hspressure(it,ii));
                     end
                     fprintf(fid, '\n');
                     fprintf(fid,'        </DataArray>\n');
@@ -808,7 +809,8 @@ classdef bodyClass<handle
                 if ~isempty(wavenonlinearpressure)
                     fprintf(fid,'        <DataArray type="Float32" Name="Wave Pressure NonLinear" NumberOfComponents="1" format="ascii">\n');
                     for ii = 1:numFace
-                        fprintf(fid, '          %i', wavenonlinearpressure.signals.values(it,ii));
+%                         fprintf(fid, '          %i', wavenonlinearpressure.signals.values(it,ii));
+                        fprintf(fid, '          %i', wavenonlinearpressure(it,ii));
                     end
                     fprintf(fid, '\n');
                     fprintf(fid,'        </DataArray>\n');
@@ -817,7 +819,8 @@ classdef bodyClass<handle
                 if ~isempty(wavelinearpressure)
                     fprintf(fid,'        <DataArray type="Float32" Name="Wave Pressure Linear" NumberOfComponents="1" format="ascii">\n');
                     for ii = 1:numFace
-                        fprintf(fid, '          %i', wavelinearpressure.signals.values(it,ii));
+%                         fprintf(fid, '          %i', wavelinearpressure.signals.values(it,ii));
+                        fprintf(fid, '          %i', wavelinearpressure(it,ii));
                     end
                     fprintf(fid, '\n');
                     fprintf(fid,'        </DataArray>\n');

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -749,7 +749,7 @@ classdef bodyClass<handle
                 vertex_mod = obj.rotateXYZ(vertex_mod,[0 0 1],pos(6));
                 vertex_mod = obj.offsetXYZ(vertex_mod,pos(1:3));
                 % open file
-                filename = [pathParaviewVideo,filesep,'vtk' filesep 'body' num2str(vtkbodiesii) '_' bodyname filesep bodyname '_' num2str(it) '.vtp'];
+                filename = [pathParaviewVideo, filesep 'body' num2str(vtkbodiesii) '_' bodyname filesep bodyname '_' num2str(it) '.vtp'];
                 fid = fopen(filename, 'w');
                 % write header
                 fprintf(fid, '<?xml version="1.0"?>\n');

--- a/source/objects/mooringClass.m
+++ b/source/objects/mooringClass.m
@@ -160,8 +160,7 @@ classdef mooringClass<handle
             end
             for it = 1:length(TimeBodyParav)
                 % open file
-                filename = [pathParaviewVideo,'\\vtk' filesep 'mooring' filesep 'mooring_' num2str(it) '.vtp'];
-                %filename = ['vtk' filesep 'mooring' filesep 'mooring_' num2str(it) '.vtp'];
+                filename = [pathParaviewVideo, filesep 'mooring' filesep 'mooring_' num2str(it) '.vtp'];
                 fid = fopen(filename, 'w');
                 % write header
                 fprintf(fid, '<?xml version="1.0"?>\n');

--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -590,7 +590,7 @@ classdef responseClass<handle
                 fs = filesep;
             end
             % open file
-            fid = fopen([pathParaviewVideo,'\\vtk' fs model(1:end-4) '.pvd'], 'w');
+            fid = fopen([pathParaviewVideo, fs model(1:end-4) '.pvd'], 'w');
             % write header
             fprintf(fid, '<?xml version="1.0"?>\n');
             fprintf(fid, ['<!-- WEC-Sim Visualization using ParaView -->\n']);

--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -164,6 +164,11 @@ classdef responseClass<handle
                     obj.bodies(ii).cellPressures_hydrostatic   = bodiesOutput(ii).hspressure.signals.values;
                     obj.bodies(ii).cellPressures_waveLinear    = bodiesOutput(ii).wpressurel.signals.values;
                     obj.bodies(ii).cellPressures_waveNonLinear = bodiesOutput(ii).wpressurenl.signals.values;
+                else
+                    obj.bodies(ii).cellPressures_time = [];
+                    obj.bodies(ii).cellPressures_hydrostatic   = [];
+                    obj.bodies(ii).cellPressures_waveLinear    = [];
+                    obj.bodies(ii).cellPressures_waveNonLinear = [];
                 end
             end
             % PTOs

--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -338,7 +338,7 @@ classdef waveClass<handle
             %
             
             % ground plane
-            filename = [pathParaviewVideo,'\\vtk' filesep 'ground.txt'];
+            filename = [pathParaviewVideo, filesep 'ground.txt'];
             fid = fopen(filename, 'w');
             fprintf(fid,[num2str(domainSize) '\n']);
             fprintf(fid,[num2str(obj.waterDepth) '\n']);
@@ -354,7 +354,7 @@ classdef waveClass<handle
             numFace = (lx-1) * (ly-1);
             for it = 1:length(t)
                 % open file
-                filename = [pathParaviewVideo,'\\vtk' filesep 'waves' filesep 'waves_' num2str(it) '.vtp'];
+                filename = [pathParaviewVideo, filesep 'waves' filesep 'waves_' num2str(it) '.vtp'];
                 fid = fopen(filename, 'w');
                 % calculate wave elevation
                 Z = waveElevationGrid (obj, t(it), X, Y, TimeBodyParav, it, g);                % write header

--- a/source/wecSim.m
+++ b/source/wecSim.m
@@ -322,6 +322,10 @@ postProcess
 if exist('userDefinedFunctions.m','file') == 2
     userDefinedFunctions;
 end
+
+% Paraview output. Must call while output is an instance of responseClass 
+paraViewVisualization
+
 % ASCII files
 if simu.outputtxt==1
     output.writetxt();
@@ -331,7 +335,6 @@ if simu.outputStructure==1
     output = struct(output);
 end
 
-paraViewVisualization
 
 %% Save files
 clear ans table tout;


### PR DESCRIPTION
This PR fixes issue #468. A previous PR (#428) changed how the pressure outputs for paraview (hspressure, wpressurenl, wpressurel) are passed in postProcess and paraViewVisualization. The references to these three pressures are now consistent.

All continuous integration tests pass. I confirmed that the Paraview application outputs correctly for every possible combination of     
simu.nlHydro, simu.pressureDis , and simu.paraview