### PR TITLE
Remove reference to removed method to repair dev docs

### DIFF
--- a/docs/man/api.rst
+++ b/docs/man/api.rst
@@ -78,15 +78,13 @@ Wave Class
 
 .. automethod:: objects.waveClass.plotSpectrum
 
-
 .. automethod:: objects.waveClass.waveSetup
+
 .. automethod:: objects.waveClass.listInfo
 
 .. automethod:: objects.waveClass.waveNumber
 
 .. automethod:: objects.waveClass.checkinputs
-
-.. automethod:: objects.waveClass.write_paraview_vtp
 
 .. automethod:: objects.waveClass.waveElevationGrid
 

--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -335,7 +335,7 @@ classdef waveClass<handle
         
         function Z = waveElevationGrid(obj, t, X, Y, TimeBodyParav, it, g)
             % This method calculates wave elevation on a grid at a given
-            % time, used by: :math:`waveClass.write_paraview_vtp`.
+            % time, used by: :func:`write_paraview_wave`.
             %             
             % Parameters
             % ------------


### PR DESCRIPTION
This commit removes an autodoc call and a reference in another method to the removed `write_paraview_vtp` method of `waveClass`. This allows the dev branch docs to build again.