### PR TITLE
Resolving #497 bug with body.cb

### DIFF
--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -26,6 +26,8 @@ classdef bodyClass<handle
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     
     properties (SetAccess = 'private', GetAccess = 'public') %hdf5 file
+        dof_start         = []                               % (`integer`) Index the DOF starts for body(``bodyNumber``). For WEC bodies this is given in the h5 file, but if not defined in the h5 file, Default = ``(bodyNumber-1)*6+1``.
+        dof_end           = []                               % (`integer`) Index the DOF ends for body(``bodyNumber``). For WEC bodies this is given in the h5 file, but if not defined in the h5 file, Default = ``(bodyNumber-1)*6+6``.
         hydroData         = struct()                                            % Hydrodynamic data from BEM or user defined.
     end
     
@@ -38,8 +40,6 @@ classdef bodyClass<handle
         dispVol           = []                               % (`float`) Displaced volume at equilibrium position [m^{3}]. For hydrodynamic bodies this is defined in the h5 file while for nonhydrodynamic bodies this is defined by the user. Default = ``[]``.
         dof               = 6                                % (`integer`) Number of degree of freedoms (DOFs). For hydrodynamic bodies this is given in the h5 file. If not defined in the h5 file, Default = ``6``.
         dof_gbm           = []                               % (`integer`) Number of degree of freedoms (DOFs) for generalized body mode (GBM). Default = ``[]``.
-        dof_start         = []                               % (`integer`) Index the DOF starts for body(``bodyNumber``). For WEC bodies this is given in the h5 file, but if not defined in the h5 file, Default = ``(bodyNumber-1)*6+1``.
-        dof_end           = []                               % (`integer`) Index the DOF ends for body(``bodyNumber``). For WEC bodies this is given in the h5 file, but if not defined in the h5 file, Default = ``(bodyNumber-1)*6+6``.
         geometryFile      = 'NONE'                           % (`string`) Pathway to the body geomtry ``.stl`` file.
         viscDrag          = struct(...                       %
             'Drag',                 zeros(6), ...            %

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -418,10 +418,11 @@ classdef bodyClass<handle
         
         function checkinputs(obj,morisonElement)
             % This method checks WEC-Sim user inputs and generates error messages if parameters are not properly defined for the bodyClass.
+            % Check h5 file
             if exist(obj.h5File,'file')==0 && obj.nhBody==0
                 error('The hdf5 file %s does not exist',obj.h5File)
             end
-            % geometry file
+            % Check geometry file
             if exist(obj.geometryFile,'file') == 0
                 error('Could not locate and open geometry file %s',obj.geometryFile)
             end
@@ -454,8 +455,7 @@ classdef bodyClass<handle
             obj.hydroForce.fExt.im=zeros(1,nDOF);
         end
         
-        function regExcitation(obj,w,waveDir,rho,g,yawFlag)
-            
+        function regExcitation(obj,w,waveDir,rho,g,yawFlag)            
             % Regular wave excitation force
             % Used by hydroForcePre
             nDOF = obj.dof;

--- a/source/wecSim.m
+++ b/source/wecSim.m
@@ -204,6 +204,10 @@ if ~isempty(idx)
     for kk = 1:length(idx)
         it = idx(kk);
         body(it).dragForcePre(simu.rho);
+        if isempty(body(it).cb)
+            body(it).cb = body(it).cg;
+            warning('Non-hydro body(%i) center of buoyancy (cb) set equal to center of gravity (cg), [%g %g %g]',body(it).bodyNumber,body(it).cb(1),body(it).cb(2),body(it).cb(3))
+        end        
     end; clear kk idx
 end
     

--- a/source/wecSim.m
+++ b/source/wecSim.m
@@ -62,7 +62,6 @@ if exist('mcr','var') == 1
     end
 end
 % Waves and Simu: check inputs
-
 waves.checkinputs;
 simu.checkinputs;
 % Constraints: count & set orientation
@@ -91,14 +90,18 @@ if exist('mooring','var') == 1
     end; clear ii
 end
 % Bodies: count, check inputs, read hdf5 file
-numHydroBodies = 0; numDragBodies = 0; 
+numHydroBodies = 0; numNonHydroBodies = 0; numDragBodies = 0; 
 hydroBodLogic = zeros(length(body(1,:)),1);
+nonHydroBodLogic = zeros(length(body(1,:)),1);
 dragBodLogic = zeros(length(body(1,:)),1);
 for ii = 1:length(body(1,:))
     body(ii).bodyNumber = ii;
     if body(ii).nhBody==0
         numHydroBodies = numHydroBodies + 1;
-        hydroBodLogic(ii) = 1; 
+        hydroBodLogic(ii) = 1;         
+    elseif body(ii).nhBody==1
+        numNonHydroBodies = numNonHydroBodies + 1;
+        nonHydroBodLogic(ii) = 1; 
     elseif body(ii).nhBody==2
         numDragBodies = numDragBodies + 1;
         dragBodLogic(ii) = 1; 
@@ -183,6 +186,18 @@ if ~isempty(idx)
     end; clear kk idx
 end
 
+% nonHydroPre
+idx = find(nonHydroBodLogic==1);
+if ~isempty(idx)
+    for kk = 1:length(idx)
+        it = idx(kk);
+        if isempty(body(it).cb)
+            body(it).cb = body(it).cg;
+            warning('Non-hydro body(%i) center of buoyancy (cb) set equal to center of gravity (cg), [%g %g %g]',body(it).bodyNumber,body(it).cb(1),body(it).cb(2),body(it).cb(3))
+        end
+    end; clear kk idx
+end      
+
 % dragBodyPre
 idx = find(dragBodLogic==1);
 if ~isempty(idx)
@@ -214,12 +229,12 @@ for ii = 1:simu.numWecBodies
     end
 end; clear ii;
 
-% check for etaImport with nlHydro
+% Check for etaImport with nlHydro
 if strcmp(waves.type,'etaImport') && simu.nlHydro == 1
     error(['Cannot run WEC-Sim with non-linear hydro (simu.nlHydro) and "etaImport" wave type'])
 end
 
-% check for etaImport with morisonElement
+% Check for etaImport with morisonElement
 if strcmp(waves.type,'etaImport') && simu.morisonElement ~= 0
     error(['Cannot run WEC-Sim with Morrison Element (simu.morisonElement) and "etaImport" wave type'])
 end


### PR DESCRIPTION
This PR resolves #497 by setting cb=cg if it's not defined and adding a warning. This is true for both non-hydro bodies and drag bodies. 
@nathanmtom please test with a non-hydro body case (e.g. WECCCOMP) by commenting out body.cb in the input file. 
@dforbush2 please test by a drag by case by commenting out body.cb in the input file. 

You should get a warning that says something like

```matlab
Warning: Non-hydro body(2) center of buoyancy (cb) set equal to center of gravity (cg), [0 0 -10.9] 
> In wecSim (line 196) 
```