### PR TITLE
add relative path in capytaine cases

### DIFF
--- a/examples/BEMIO/CAPYTAINE/Coer_Comp/coer_comp.py
+++ b/examples/BEMIO/CAPYTAINE/Coer_Comp/coer_comp.py
@@ -3,7 +3,7 @@
 Created on Thu Nov  10 13:15:35 2020
 
 @author: akeeste
-This script recreates an coercomp model based on sample BEM 
+This script recreates the coercomp model based on sample BEM 
 parameters from WEC-Sim (frequency range, directions, etc)
 
 """
@@ -12,10 +12,11 @@ parameters from WEC-Sim (frequency range, directions, etc)
 import numpy as np
 import os
 import sys
-sys.path.insert(1,'C:/Users/akeeste/Documents/Software/GitHub/capytaine/my_cases')
 
-import call_capytaine as cc # call_capytaine.py has some mods from david's original function
-
+# Add directory with the call_capytaine.py file to the system path.
+currentdir = os.path.dirname(os.getcwd())
+sys.path.append(currentdir)
+import call_capytaine as cc
 
 # Define Coercomp parameters -------------------------------------------------#
 coercomp_file = ((os.getcwd() + os.path.sep + 'coer_comp.dat'),) # mesh files, .dat nemoh, .gdf wamit

--- a/examples/BEMIO/CAPYTAINE/Cubes/cubes.py
+++ b/examples/BEMIO/CAPYTAINE/Cubes/cubes.py
@@ -1,8 +1,8 @@
+# -*- coding: utf-8 -*-
 """
 Created on Thu Nov  10 13:15:35 2020
 
 @author: akeeste
-
 This script recreates the cubes model on sample BEM 
 parameters from WEC-Sim (frequency range, directions, etc)
 
@@ -12,10 +12,11 @@ parameters from WEC-Sim (frequency range, directions, etc)
 import numpy as np
 import os
 import sys
-sys.path.insert(1,'C:/Users/akeeste/Documents/Software/GitHub/capytaine/my_cases')
 
-import call_capytaine as cc # call_capytaine.py has some mods from david's original function
-
+# Add directory with the call_capytaine.py file to the system path.
+currentdir = os.path.dirname(os.getcwd())
+sys.path.append(currentdir)
+import call_capytaine as cc
 
 # Define cubes parameters ----------------------------------------------------#
 cubes_file = (os.getcwd() + os.path.sep + 'r_cube.dat',

--- a/examples/BEMIO/CAPYTAINE/Cylinder/cylinder.py
+++ b/examples/BEMIO/CAPYTAINE/Cylinder/cylinder.py
@@ -3,7 +3,7 @@
 Created on Thu Nov  10 13:15:35 2020
 
 @author: akeeste
-This script recreates an cylinder model based on sample BEM 
+This script recreates the cylinder model based on sample BEM 
 parameters from WEC-Sim (frequency range, directions, etc)
 
 """
@@ -12,10 +12,11 @@ parameters from WEC-Sim (frequency range, directions, etc)
 import numpy as np
 import os
 import sys
-sys.path.insert(1,'C:/Users/akeeste/Documents/Software/GitHub/capytaine/my_cases')
 
-import call_capytaine as cc # call_capytaine.py has some mods from david's original function
-
+# Add directory with the call_capytaine.py file to the system path.
+currentdir = os.path.dirname(os.getcwd())
+sys.path.append(currentdir)
+import call_capytaine as cc
 
 # Define cylinder parameters -------------------------------------------------#
 cylinder_file = ((os.getcwd() + os.path.sep + 'cylinder.dat'),) # mesh file, .dat nemoh, .gdf wamit

--- a/examples/BEMIO/CAPYTAINE/Ellipsoid/ellipsoid.py
+++ b/examples/BEMIO/CAPYTAINE/Ellipsoid/ellipsoid.py
@@ -3,7 +3,7 @@
 Created on Thu Nov  10 13:15:35 2020
 
 @author: akeeste
-This script recreates an ellipsoid model based on sample BEM 
+This script recreates the ellipsoid model based on sample BEM 
 parameters from WEC-Sim (frequency range, directions, etc)
 
 """
@@ -12,10 +12,11 @@ parameters from WEC-Sim (frequency range, directions, etc)
 import numpy as np
 import os
 import sys
-sys.path.insert(1,'C:/Users/akeeste/Documents/Software/GitHub/capytaine/my_cases')
 
-import call_capytaine as cc # call_capytaine.py has some mods from david's original function
-
+# Add directory with the call_capytaine.py file to the system path.
+currentdir = os.path.dirname(os.getcwd())
+sys.path.append(currentdir)
+import call_capytaine as cc
 
 # Define ellipsoid parameters ------------------------------------------------#
 ellipsoid_file = ((os.getcwd() + os.path.sep + 'ellipsoid.dat'),) # mesh file, .dat nemoh, .gdf wamit

--- a/examples/BEMIO/CAPYTAINE/OSWEC/oswec.py
+++ b/examples/BEMIO/CAPYTAINE/OSWEC/oswec.py
@@ -1,12 +1,5 @@
 # -*- coding: utf-8 -*-
 """
-Created on Mon Nov  10 13:35:00 2020
-
-@author: akeeste
-"""
-
-# -*- coding: utf-8 -*-
-"""
 Created on Thu Nov  5 13:15:35 2020
 
 @author: akeeste
@@ -19,10 +12,11 @@ parameters from WEC-Sim (frequency range, directions, etc)
 import numpy as np
 import os
 import sys
-sys.path.insert(1,'C:/Users/akeeste/Documents/Software/GitHub/capytaine/my_cases')
 
-import call_capytaine as cc # call_capytaine.py has some mods from david's original function
-
+# Add directory with the call_capytaine.py file to the system path.
+currentdir = os.path.dirname(os.getcwd())
+sys.path.append(currentdir)
+import call_capytaine as cc
 
 # Define OSWEC parameters ----------------------------------------------------#
 oswec_file = (os.getcwd() + os.path.sep + 'flap.dat',

--- a/examples/BEMIO/CAPYTAINE/RM3/rm3.py
+++ b/examples/BEMIO/CAPYTAINE/RM3/rm3.py
@@ -12,10 +12,11 @@ parameters from WEC-Sim (frequency range, directions, etc)
 import numpy as np
 import os
 import sys
-sys.path.insert(1,'C:/Users/akeeste/Documents/Software/GitHub/capytaine/my_cases')
 
+# Add directory with the call_capytaine.py file to the system path.
+currentdir = os.path.dirname(os.getcwd())
+sys.path.append(currentdir)
 import call_capytaine as cc
-
 
 # Define RM3 parameters ------------------------------------------------------#
 rm3_file = (os.getcwd() + os.path.sep + 'float.dat',

--- a/examples/BEMIO/CAPYTAINE/Sphere/sphere.py
+++ b/examples/BEMIO/CAPYTAINE/Sphere/sphere.py
@@ -12,10 +12,11 @@ parameters from WEC-Sim (frequency range, directions, etc)
 import numpy as np
 import os
 import sys
-sys.path.insert(1,'C:/Users/akeeste/Documents/Software/GitHub/capytaine/my_cases')
 
+# Add directory with the call_capytaine.py file to the system path.
+currentdir = os.path.dirname(os.getcwd())
+sys.path.append(currentdir)
 import call_capytaine as cc
-
 
 # Define sphere parameters ---------------------------------------------------#
 sphere_file = ((os.getcwd() + os.path.sep + 'sphere.dat'),) # mesh file, .dat nemoh, .gdf wamit

--- a/examples/BEMIO/CAPYTAINE/run_cases.py
+++ b/examples/BEMIO/CAPYTAINE/run_cases.py
@@ -4,7 +4,8 @@ Created on Wed Nov 18 11:32:31 2020
 
 @author: akeeste
 
-This script runs all of the current cases for WEC-Sim bemio examples.
+This script runs all of the Capytaine cases needed for the WEC-Sim bemio examples.
+This script runs Capytaine, not BEMIO.
 
 """
 import os
@@ -31,7 +32,7 @@ import coer_comp
 
 # # Multiple body cases ------------------------------------------------------#
 print('Run Cubes case') # 11000 problems, 8.5 hours (new b2b)
-os.chdir("./Cubes")
+os.chdir("../Cubes")
 import cubes
 
 print('Run RM3 case') # 3380 problems, 21 hours (new b2b)


### PR DESCRIPTION
Fixes a line in the Capytaine case files (sphere.py, ellipsoid.py, etc) that imported the call_capytaine.py file using an absolute path. This changes those lines to import the function using a relative path that should work for all users.