### PR TITLE
resolving #514

### DIFF
--- a/source/objects/simulationClass.m
+++ b/source/objects/simulationClass.m
@@ -54,7 +54,7 @@ classdef simulationClass<handle
         mcrCaseFile         = []                                           % (`string`) mat file that contain a list of the multiple conditions runs with given conditions. Default = ``'NOT DEFINED'``  
         morisonElement      = 0                                            % (`integer`) Option for Morison Element calculation: off->0, on->1 or 2. Default = ``0``. Option 1 uses an approach that allows the user to define drag and inertial coefficients along the x-, y-, and z-axes and Option 2 uses an approach that defines the Morison Element with normal and tangential tangential drag and interial coefficients.. 
         reloadH5Data        = 0                                            % (`integer`) Option to re-load hydro data from hf5 file between runs: off->0, on->1. Default = ``0``
-        saveStructure       = 1                                            % (`integer`) Option to save results as a MATLAB structure: off->0, on->1. Default = ``1``
+        saveStructure       = 0                                            % (`integer`) Option to save results as a MATLAB structure: off->0, on->1. Default = ``1``
         saveText            = 0                                            % (`integer`) Option to save results as ASCII files off->0, on->1. Default = ``0``
         saveWorkspace       = 1                                            % (`integer`) Option to save .mat file for each run: off->0, on->1. Default = ``1``
         pressureDis         = 0                                            % (`integer`) Option to save pressure distribution: off->0, on->1. Default = ``0``

--- a/source/objects/simulationClass.m
+++ b/source/objects/simulationClass.m
@@ -53,10 +53,10 @@ classdef simulationClass<handle
         adjMassWeightFun    = 2                                            % (`integer`) Weighting function for adjusting added mass term in the translational direction. Default = ``2``
         mcrCaseFile         = []                                           % (`string`) mat file that contain a list of the multiple conditions runs with given conditions. Default = ``'NOT DEFINED'``  
         morisonElement      = 0                                            % (`integer`) Option for Morison Element calculation: off->0, on->1 or 2. Default = ``0``. Option 1 uses an approach that allows the user to define drag and inertial coefficients along the x-, y-, and z-axes and Option 2 uses an approach that defines the Morison Element with normal and tangential tangential drag and interial coefficients.. 
-        outputtxt           = 0                                            % (`integer`) Option to save results as ASCII files off->0, on->1. Default = ``0``
-        outputStructure     = 1                                            % (`integer`) Option to save results as a MATLAB structure: off->0, on->1. Default = ``1``
         reloadH5Data        = 0                                            % (`integer`) Option to re-load hydro data from hf5 file between runs: off->0, on->1. Default = ``0``
-        saveMat             = 1                                            % (`integer`) Option to save .mat file for each run: off->0, on->1. Default = ``1``
+        saveStructure       = 1                                            % (`integer`) Option to save results as a MATLAB structure: off->0, on->1. Default = ``1``
+        saveText            = 0                                            % (`integer`) Option to save results as ASCII files off->0, on->1. Default = ``0``
+        saveWorkspace       = 1                                            % (`integer`) Option to save .mat file for each run: off->0, on->1. Default = ``1``
         pressureDis         = 0                                            % (`integer`) Option to save pressure distribution: off->0, on->1. Default = ``0``
     end
 

--- a/source/wecSim.m
+++ b/source/wecSim.m
@@ -395,12 +395,12 @@ end
 paraViewVisualization
 
 % ASCII files
-if simu.outputtxt==1
+if simu.saveText==1
     output.writetxt();
 end
-if simu.outputStructure==1
+if simu.saveStructure==1
     warning('off','MATLAB:structOnObject')
-    output = struct(output);
+    outputStructure = struct(output);
 end
 
 
@@ -409,7 +409,7 @@ clear ans table tout;
 toc
 diary off
 
-if simu.saveMat==1
+if simu.saveWorkspace==1
     try 
        cd(parallelComputing_dir);
        simu.caseDir = [simu.caseDir filesep parallelComputing_dir];


### PR DESCRIPTION
Instead of moving the plotting scripts outside of the `responseClass`, a solution that would require us to revise all working cases, I opted to keep the output object called `output`, but also save an output structure called `outputStructure`. Open to feedback. 