### PR TITLE
Fixes #459. Update ParaView macros for Paraview 5.9

### DIFF
--- a/docs/_include/viz.rst
+++ b/docs/_include/viz.rst
@@ -20,7 +20,7 @@ It should only be turned on when visualization is desired. The user also needs t
 
 Getting Started - Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-You will need to install `Paraview <http://www.paraview.org/>`_ and install and setup Python.  
+You will need to install `Paraview 5.9.1 <http://www.paraview.org/>`_.  
 Next you will need to add some WEC-Sim specific macros, as follows:
 
 * Open Paraview
@@ -77,18 +77,17 @@ When ``simu.paraview`` is set to 1, a user-specified directory containing ``vtk`
 All files necessary for Paraview visualization are located there.
 To view in Paraview:
 
-* Open the ``YOUR_PATH/vtk/filename.pvd`` file in Paraview
-* Click ``Apply``
+* Open the ``$CASE/vtk/filename.pvd`` file in Paraview
 * With the model selected in the pipeline, run the ``WEC-Sim`` macro
 * Move the camera to desired view
 * Click the green arrow (play) button
 
-The WEC-Sim macro:
+The ``WEC-Sim`` macro:
 
 * Extracts each body, sets the color and opacity, and renames them
 * Extracts the waves, sets color and opacity, and renames
 * Creates the ground plane
-* Sets the camera to ``parallel view``
+* Sets the camera to top view
 
 
 Basic Visualization Manipulation
@@ -123,6 +122,15 @@ The ``pressureGlyphs`` macro calculates cell normals, and cell centers. It then 
 * Total pressure (hydrostatic plus non-linear Froude-Krylov)
 * Froude-Krylov delta (non-linear minus linear)
 
+To view in Paraview:
+
+* Open the ``$CASE/vtk/filename.pvd`` file in Paraview
+* With the model selected in the pipeline, run the ``WEC-Sim`` macro
+* Move the camera to desired view
+* With the non-linear hydro body selected in the pipeline, run the ``pressureGlyphs`` macro
+* Select which features to visualize in the pipline
+* Click the green arrow (play) button
+
 The video below shows three different views of the RM3 model described in the tutorials.
 The top right shows glyphs of the non-linear Froude-Krylov pressure acting on the float. 
 The bottom right shows the float colored by hydrostatic pressure.
@@ -131,3 +139,7 @@ The bottom right shows the float colored by hydrostatic pressure.
 
 	<iframe width="420" height="315" src="https://www.youtube.com/embed/VIPXsS8h9pg" frameborder="0" allowfullscreen></iframe>
 
+
+Loading a State File
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If a previous Paraview `*.pvsm`` state file was saved, the state can be applied to a different ``*.pvd`` Paraview file.

--- a/source/functions/paraview/pressureGlyphs.py
+++ b/source/functions/paraview/pressureGlyphs.py
@@ -1,120 +1,128 @@
 #### import the simple module from the paraview
 from paraview.simple import *
 
+renderView1 = GetActiveViewOrCreate('RenderView')
+
 body = GetActiveSource()
 generateSurfaceNormals1 = GenerateSurfaceNormals(Input=body)
 generateSurfaceNormals1.ComputeCellNormals = 1
 cellCenters1 = CellCenters(Input=generateSurfaceNormals1)
 
 scale = 0.0001
-try:
-	calculator1 = Calculator(Input=cellCenters1)
-	calculator1.Function = 'Hydrostatic Pressure * Normals'
-	calculator1.ResultArrayName = 'hydrostatic_pressure'
-	glyph1 = Glyph(Input=calculator1, GlyphType='Arrow')
-	glyph1.Scalars = ['POINTS', 'Cell Area']
-	glyph1.Vectors = ['POINTS', 'hydrostatic_pressure']
-	glyph1.ScaleMode = 'vector'
-	glyph1.ScaleFactor = scale
-	glyph1.GlyphMode = 'All Points'
-	glyph1.GlyphType.Invert = 1
-	glyph1Display = GetDisplayProperties(glyph1, view=renderView1)
-	ColorBy(glyph1Display, ('POINTS', 'GlyphVector'))
-	glyph1Display.RescaleTransferFunctionToDataRange(True)
-	glyph1Display.SetScalarBarVisibility(renderView1, True)	
-	Hide(glyph1, renderView1)
-	RenameSource('calculator: hydrostatic_pressure', calculator1)
-	RenameSource('glyph: hydrostatic_pressure', glyph1)
-except:
-	Delete(calculator1)
-	del calculator1
 
 try:
-	calculator2 = Calculator(Input=cellCenters1)
-	calculator2.Function = 'Wave Pressure Linear * Normals'
-	calculator2.ResultArrayName = 'froude-krylov_pressure_linear'
-	glyph2 = Glyph(Input=calculator2, GlyphType='Arrow')
-	glyph2.Scalars = ['POINTS', 'Cell Area']
-	glyph2.Vectors = ['POINTS', 'froude-krylov_pressure_linear']
-	glyph2.ScaleMode = 'vector'
-	glyph2.ScaleFactor = scale
-	glyph2.GlyphMode = 'All Points'
-	glyph2.GlyphType.Invert = 1
-	glyph2Display = GetDisplayProperties(glyph2, view=renderView1)
-	ColorBy(glyph2Display, ('POINTS', 'GlyphVector'))
-	glyph2Display.RescaleTransferFunctionToDataRange(True)
-	glyph2Display.SetScalarBarVisibility(renderView1, True)	
-	Hide(glyph2, renderView1)
-	RenameSource('calculator: froude-krylov_pressure_linear', calculator2)
-	RenameSource('glyph: froude-krylov_pressure_linear', glyph2)
+    calculator1 = Calculator(Input=cellCenters1)
+    calculator1.Function = 'Hydrostatic Pressure * Normals'
+    calculator1.ResultArrayName = 'hydrostatic_pressure'
+    glyph1 = Glyph(Input=calculator1, GlyphType='Arrow')
+    glyph1.OrientationArray = ['POINTS', 'hydrostatic_pressure']
+    glyph1.ScaleArray = ['POINTS', 'hydrostatic_pressure']
+    glyph1.ScaleFactor = scale
+    glyph1.GlyphMode = 'All Points'
+    glyph1.GlyphType.Invert = 1
+    glyph1Display = GetDisplayProperties(glyph1, view=renderView1)
+    ColorBy(glyph1Display, ('POINTS', 'hydrostatic_pressure', 'Magnitude'))
+    glyph1Display.RescaleTransferFunctionToDataRange(True)
+    glyph1Display.SetScalarBarVisibility(renderView1, True)
+    Hide(glyph1, renderView1)
+    RenameSource('calculator: hydrostatic_pressure', calculator1)
+    RenameSource('glyph: hydrostatic_pressure', glyph1)
 except:
-	Delete(calculator2)
-	del calculator2
+    Delete(calculator1)
+    del calculator1
+    Delete(glyph1)
+    del glyph1
 
 try:
-	calculator3 = Calculator(Input=cellCenters1)
-	calculator3.Function = 'Wave Pressure NonLinear * Normals'
-	calculator3.ResultArrayName = 'froude-krylov_pressure_non-linear'
-	glyph3 = Glyph(Input=calculator3, GlyphType='Arrow')
-	glyph3.Scalars = ['POINTS', 'Cell Area']
-	glyph3.Vectors = ['POINTS', 'froude-krylov_pressure_non-linear']
-	glyph3.ScaleMode = 'vector'
-	glyph3.ScaleFactor = scale
-	glyph3.GlyphMode = 'All Points'
-	glyph3.GlyphType.Invert = 1
-	glyph3Display = GetDisplayProperties(glyph3, view=renderView1)
-	ColorBy(glyph3Display, ('POINTS', 'GlyphVector'))
-	glyph3Display.RescaleTransferFunctionToDataRange(True)
-	glyph3Display.SetScalarBarVisibility(renderView1, True)	
-	Hide(glyph3, renderView1)
-	RenameSource('calculator: froude-krylov_pressure_non-linear', calculator3)
-	RenameSource('glyph: froude-krylov_pressure_non-linear', glyph3)
+    calculator2 = Calculator(Input=cellCenters1)
+    calculator2.Function = 'Wave Pressure Linear * Normals'
+    calculator2.ResultArrayName = 'froude-krylov_pressure_linear'
+    glyph2 = Glyph(Input=calculator2, GlyphType='Arrow')
+    glyph2.OrientationArray = ['POINTS', 'froude-krylov_pressure_linear']
+    glyph2.ScaleArray = ['POINTS', 'froude-krylov_pressure_linear']
+    glyph2.ScaleFactor = scale
+    glyph2.GlyphMode = 'All Points'
+    glyph2.GlyphType.Invert = 1
+    glyph2Display = GetDisplayProperties(glyph2, view=renderView1)
+    ColorBy(glyph2Display, ('POINTS', 'froude-krylov_pressure_linear', 'Magnitude'))
+    glyph2Display.RescaleTransferFunctionToDataRange(True)
+    glyph2Display.SetScalarBarVisibility(renderView1, True)
+    Hide(glyph2, renderView1)
+    RenameSource('calculator: froude-krylov_pressure_linear', calculator2)
+    RenameSource('glyph: froude-krylov_pressure_linear', glyph2)
 except:
-	Delete(calculator3)
-	del calculator3
+    Delete(calculator2)
+    del calculator2
+    Delete(glyph2)
+    del glyph2
 
 try:
-	calculator4 = Calculator(Input=cellCenters1)
-	calculator4.Function = '(Hydrostatic Pressure + Wave Pressure NonLinear) * Normals'
-	calculator4.ResultArrayName = 'total_pressure'
-	glyph4 = Glyph(Input=calculator4, GlyphType='Arrow')
-	glyph4.Scalars = ['POINTS', 'Cell Area']
-	glyph4.Vectors = ['POINTS', 'total_pressure']
-	glyph4.ScaleMode = 'vector'
-	glyph4.ScaleFactor = scale
-	glyph4.GlyphMode = 'All Points'
-	glyph4.GlyphType.Invert = 1
-	glyph4Display = GetDisplayProperties(glyph4, view=renderView1)
-	ColorBy(glyph4Display, ('POINTS', 'GlyphVector'))
-	glyph4Display.RescaleTransferFunctionToDataRange(True)
-	glyph4Display.SetScalarBarVisibility(renderView1, True)	
-	Hide(glyph4, renderView1)
-	RenameSource('calculator: total_pressure', calculator4)
-	RenameSource('glyph: total_pressure', glyph4)
+    calculator3 = Calculator(Input=cellCenters1)
+    calculator3.Function = 'Wave Pressure NonLinear * Normals'
+    calculator3.ResultArrayName = 'froude-krylov_pressure_non-linear'
+    glyph3 = Glyph(Input=calculator3, GlyphType='Arrow')
+    glyph3.OrientationArray = ['POINTS', 'froude-krylov_pressure_non-linear']
+    glyph3.ScaleArray = ['POINTS', 'froude-krylov_pressure_non-linear']
+    glyph3.ScaleFactor = scale
+    glyph3.GlyphMode = 'All Points'
+    glyph3.GlyphType.Invert = 1
+    glyph3Display = GetDisplayProperties(glyph3, view=renderView1)
+    ColorBy(glyph3Display, ('POINTS',
+            'froude-krylov_pressure_non-linear', 'Magnitude'))
+    glyph3Display.RescaleTransferFunctionToDataRange(True)
+    glyph3Display.SetScalarBarVisibility(renderView1, True)
+    Hide(glyph3, renderView1)
+    RenameSource('calculator: froude-krylov_pressure_non-linear', calculator3)
+    RenameSource('glyph: froude-krylov_pressure_non-linear', glyph3)
 except:
-	Delete(calculator4)
-	del calculator4
+    Delete(calculator3)
+    del calculator3
+    Delete(glyph3)
+    del glyph3
+
+try:
+    calculator4 = Calculator(Input=cellCenters1)
+    calculator4.Function = '(Hydrostatic Pressure + Wave Pressure NonLinear) * Normals'
+    calculator4.ResultArrayName = 'total_pressure'
+    glyph4 = Glyph(Input=calculator4, GlyphType='Arrow')
+    glyph4.OrientationArray = ['POINTS', 'total_pressure']
+    glyph4.ScaleArray = ['POINTS', 'total_pressure']
+    glyph4.ScaleFactor = scale
+    glyph4.GlyphMode = 'All Points'
+    glyph4.GlyphType.Invert = 1
+    glyph4Display = GetDisplayProperties(glyph4, view=renderView1)
+    ColorBy(glyph4Display, ('POINTS', 'total_pressure', 'Magnitude'))
+    glyph4Display.RescaleTransferFunctionToDataRange(True)
+    glyph4Display.SetScalarBarVisibility(renderView1, True)
+    Hide(glyph4, renderView1)
+    RenameSource('calculator: total_pressure', calculator4)
+    RenameSource('glyph: total_pressure', glyph4)
+except:
+    Delete(calculator4)
+    del calculator4
+    Delete(glyph4)
+    del glyph4
 
 
 try:
-	calculator5 = Calculator(Input=cellCenters1)
-	calculator5.Function = '(Wave Pressure NonLinear - Wave Pressure Linear) * Normals'
-	calculator5.ResultArrayName = 'froude-krylov_delta_pressure'
-	glyph5 = Glyph(Input=calculator5, GlyphType='Arrow')
-	glyph5.Scalars = ['POINTS', 'Cell Area']
-	glyph5.Vectors = ['POINTS', 'froude-krylov_delta_pressure']
-	glyph5.ScaleMode = 'vector'
-	glyph5.ScaleFactor = scale
-	glyph5.GlyphMode = 'All Points'
-	glyph5.GlyphType.Invert = 1
-	glyph5Display = GetDisplayProperties(glyph5, view=renderView1)
-	ColorBy(glyph5Display, ('POINTS', 'GlyphVector'))
-	glyph5Display.RescaleTransferFunctionToDataRange(True)
-	glyph5Display.SetScalarBarVisibility(renderView1, True)	
-	Hide(glyph5, renderView1)
-	RenameSource('calculator: froude-krylov_delta_pressure', calculator5)
-	RenameSource('glyph: froude-krylov_delta_pressure', glyph5)
+    calculator5 = Calculator(Input=cellCenters1)
+    calculator5.Function = '(Wave Pressure NonLinear - Wave Pressure Linear) * Normals'
+    calculator5.ResultArrayName = 'froude-krylov_delta_pressure'
+    glyph5 = Glyph(Input=calculator5, GlyphType='Arrow')
+    glyph5.OrientationArray = ['POINTS', 'froude-krylov_delta_pressure']
+    glyph5.ScaleArray = ['POINTS', 'froude-krylov_delta_pressure']
+    glyph5.ScaleFactor = scale
+    glyph5.GlyphMode = 'All Points'
+    glyph5.GlyphType.Invert = 1
+    glyph5Display = GetDisplayProperties(glyph5, view=renderView1)
+    ColorBy(glyph5Display, ('POINTS', 'froude-krylov_delta_pressure', 'Magnitude'))
+    glyph5Display.RescaleTransferFunctionToDataRange(True)
+    glyph5Display.SetScalarBarVisibility(renderView1, True)
+    Hide(glyph5, renderView1)
+    RenameSource('calculator: froude-krylov_delta_pressure', calculator5)
+    RenameSource('glyph: froude-krylov_delta_pressure', glyph5)
 except:
-	Delete(calculator5)
-	del calculator5
-
+    Delete(calculator5)
+    del calculator5
+    Delete(glyph5)
+    del glyph5


### PR DESCRIPTION
Update the ParaView _pressureGlyphs.py_ macro for the latest ParaView version (5.9.1). The issue was that the current version of ParaView is not backwards compatible. 

@kmruehl To Do:

- [ ] Create new .pvsm files for the _WEC-Sim_Applications/Paraview_Visualization_ cases using Paraview 5.9.1
- [x]  Test new macro on _WEC-Sim_Applications/Paraview_Visualization/RM3_MoorDyn_Viz_. Currently only tested on _WEC-Sim_Applications/Paraview_Visualization/OSWEC_NonLinear_Viz_. 
-  [x] Mention the supported ParaView version somewhere in the Documentation or website. 