### PR TITLE
Fix Combine_BEM Ainf initialization

### DIFF
--- a/source/functions/BEMIO/Normalize.m
+++ b/source/functions/BEMIO/Normalize.m
@@ -49,6 +49,7 @@ end
 if strcmp(hydro(F).code,'WAMIT')==0  % Normalize
     hydro(F).C = hydro(F).C/(hydro(F).g*hydro(F).rho);
     hydro(F).A = hydro(F).A/(hydro(F).rho);
+    hydro(F).Ainf = hydro(F).A(:,:,end); % overwritten with more accurate method by Radiation_IRF.m 
     for i=1:length(hydro(F).w)
         hydro(F).B(:,:,i) = hydro(F).B(:,:,i)/(hydro(F).rho*hydro(F).w(i));
     end


### PR DESCRIPTION
This PR resolves issue #601. There is a small bug that only occurs when non-WAMIT codes are used in the Combine_BEM() BEMIO function. 

The initialization of hydro.Ainf is added into Normalize.m for all non-WAMIT codes, so that they can be properly concatenated in the Combine_BEM function. I added an inline comment stating that the initial value (added mass at the highest frequency given) is overwritten by more accurate method in radiation_IRF.m