### PR TITLE
Clear temporary variable added in startup.m

### DIFF
--- a/source/wecSimStartup.m
+++ b/source/wecSimStartup.m
@@ -4,4 +4,4 @@
 
 wecSimPath = '<wecSim>';
 addpath(genpath(wecSimPath));
-
+clear wecSimPath


### PR DESCRIPTION
I was reinstalling WEC-Sim on a new operating system and I remembered that one of the annoying aspects of using the `startup.m` file was the temporary variable `wecSimPath` being placed into the global workspace. 

I don't believe this variable is needed in any other situation, so my preference is to clear it from the workspace, which this PR does automatically. 