### PR TITLE
Use the caller workspace when reading ptosim outputs

### DIFF
--- a/source/objects/ptoSimClass.m
+++ b/source/objects/ptoSimClass.m
@@ -136,7 +136,7 @@ classdef ptoSimClass<handle
                 for jj = 1:length(obj.(names{ii}))
                     for kk = 1:length(signals.(names{ii}))
                         try
-                            tmp = evalin('base',[names{ii} num2str(jj) '_out.signals.values(:,' num2str(kk) ')']);
+                            tmp = evalin('caller',[names{ii} num2str(jj) '_out.signals.values(:,' num2str(kk) ')']);
                             ptosimOutput.(names{ii})(jj).(signals.(names{ii}){kk}) = tmp;
                         end
                     end


### PR DESCRIPTION
This change allows the [PTOSim application examples](https://github.com/WEC-Sim/WEC-Sim_Applications/tree/master/PTO-Sim/) to run in function and class based tests.

I am not sure if I've covered all the use cases where this change might cause an issue, but it works for me when running wecSim in the application directory (i.e. in [OSWEC_Hydraulic_PTO](https://github.com/WEC-Sim/WEC-Sim_Applications/tree/master/PTO-Sim/OSWEC/OSWEC_Hydraulic_PTO)) and it now also works for the class based tests in https://github.com/WEC-Sim/WEC-Sim_Applications/pull/7

I've put this PR against master in order to get the WEC-Sim_Applications suite passing against the master branch. I am pretty sure that it will also merge into dev without issue.