### PR TITLE
Fix link tag address in gh-pages redirect html page

### DIFF
--- a/docs/_assets/gh-pages-redirect.html
+++ b/docs/_assets/gh-pages-redirect.html
@@ -4,6 +4,6 @@
     <title>Redirecting to master branch</title>
     <meta charset="utf-8">
     <meta http-equiv="refresh" content="0; url=./master/index.html">
-    <link rel="canonical" href="https://username.github.io/reponame/master/index.html">
+    <link rel="canonical" href="https://wec-sim.github.io/WEC-Sim/master/index.html">
   </head>
 </html>


### PR DESCRIPTION
This isn't super important because the link tag here is more for information than anything practical. This is just correcting an error in the given link address.