### PR TITLE
Add MATLAB R2020a to CI tests

### DIFF
--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -10,7 +10,7 @@ on:
       - dev
 jobs:
   test_latest:
-    name: Run Latest MATLAB
+    name: MATLAB Latest 
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -29,8 +29,8 @@ jobs:
         uses: matlab-actions/run-command@v1
         with:
           command: results = wecSimTest, assertSuccess(results);
-  test_2020a:
-    name: Run MATLAB 2020a
+  test_r2020a:
+    name: MATLAB R2020a
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -9,8 +9,8 @@ on:
     branches:
       - dev
 jobs:
-  test:
-    name: Run MATLAB Tests and Generate Artifacts
+  test_latest:
+    name: Run Latest MATLAB
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -21,6 +21,28 @@ jobs:
         run: git lfs checkout
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
+      - name: Install WEC-Sim
+        uses: matlab-actions/run-command@v1
+        with:
+          command: addpath(genpath('source'));, savepath pathdef.m;
+      - name: Run tests and generate artifacts
+        uses: matlab-actions/run-command@v1
+        with:
+          command: results = wecSimTest, assertSuccess(results);
+  test_2020a:
+    name: Run MATLAB 2020a
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Checkout LFS objects
+        run: git lfs checkout
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v1
+        with:
+            release: 2020a
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -9,40 +9,23 @@ on:
     branches:
       - dev
 jobs:
-  test_latest:
-    name: MATLAB Latest 
+  run_tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release: [R2020a, latest]
+    name: MATLAB ${{ matrix.release }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
         with:
           lfs: true
-      - name: Checkout LFS objects
-        run: git lfs checkout
-      - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v1
-      - name: Install WEC-Sim
-        uses: matlab-actions/run-command@v1
-        with:
-          command: addpath(genpath('source'));, savepath pathdef.m;
-      - name: Run tests and generate artifacts
-        uses: matlab-actions/run-command@v1
-        with:
-          command: results = wecSimTest, assertSuccess(results);
-  test_r2020a:
-    name: MATLAB R2020a
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-        with:
-          lfs: true
-      - name: Checkout LFS objects
+      - name: Check out LFS objects
         run: git lfs checkout
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
         with:
-            release: R2020a
+            release: ${{ matrix.release }}
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
         with:
-            release: 2020a
+            release: R2020a
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:

--- a/.github/workflows/run-tests-master.yml
+++ b/.github/workflows/run-tests-master.yml
@@ -9,8 +9,8 @@ on:
     branches:
       - master
 jobs:
-  test:
-    name: Run MATLAB Tests and Generate Artifacts
+  test_latest:
+    name: MATLAB Latest 
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -21,6 +21,28 @@ jobs:
         run: git lfs checkout
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
+      - name: Install WEC-Sim
+        uses: matlab-actions/run-command@v1
+        with:
+          command: addpath(genpath('source'));, savepath pathdef.m;
+      - name: Run tests and generate artifacts
+        uses: matlab-actions/run-command@v1
+        with:
+          command: results = wecSimTest, assertSuccess(results);
+  test_r2020a:
+    name: MATLAB R2020a
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Checkout LFS objects
+        run: git lfs checkout
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v1
+        with:
+            release: R2020a
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:

--- a/.github/workflows/run-tests-master.yml
+++ b/.github/workflows/run-tests-master.yml
@@ -9,29 +9,12 @@ on:
     branches:
       - master
 jobs:
-  test_latest:
-    name: MATLAB Latest 
+  run_tests:
     runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-        with:
-          lfs: true
-      - name: Checkout LFS objects
-        run: git lfs checkout
-      - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v1
-      - name: Install WEC-Sim
-        uses: matlab-actions/run-command@v1
-        with:
-          command: addpath(genpath('source'));, savepath pathdef.m;
-      - name: Run tests and generate artifacts
-        uses: matlab-actions/run-command@v1
-        with:
-          command: results = wecSimTest, assertSuccess(results);
-  test_r2020a:
-    name: MATLAB R2020a
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release: [R2020a, latest]
+    name: MATLAB ${{ matrix.release }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -42,7 +25,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
         with:
-            release: R2020a
+            release: ${{ matrix.release }}
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:

--- a/.github/workflows/run-tests-master.yml
+++ b/.github/workflows/run-tests-master.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           lfs: true
-      - name: Checkout LFS objects
+      - name: Check out LFS objects
         run: git lfs checkout
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1


### PR DESCRIPTION
Adds a new job to tests in master and dev branch (once merged) to test code against both latest and R2020a versions of MATLAB.