### PR TITLE
Disable moorDynInput method

### DIFF
--- a/source/objects/mooringClass.m
+++ b/source/objects/mooringClass.m
@@ -104,7 +104,6 @@ classdef mooringClass<handle
 
         function obj = moorDynInput(obj)
             % Method to read MoorDyn input file
-            obj.moorDynInputRaw = textread('./mooring/lines.txt', '%s', 'delimiter', '\n');
         end
 
         function listInfo(obj)


### PR DESCRIPTION
This is a follow-up to #677, which simply disables the `mooringClass.moorDynInput` method. As far as I can see, `mooringClass.moorDynInput` and the `moorDynInputRaw` property have no functional usage. My testing also indicated that `mooringClass.moorDynInput` can end up racing for access of the `lines.txt` file with `MoorDyn` which is another source of failure. So the easiest thing to do, to me, is to stop it running. This also fixes the case sensitivity problem detailed below for Linux.

Currently, MoorDyn requires that the `Mooring` folder (which contains the `lines.txt` file) should have a capital Em as shown by [this line](https://github.com/mattEhall/MoorDyn/blob/ea5ccf8c050f359cdd13a0a8b6f5cc5f3158405c/MoorDyn.cpp#L287) in the [MoorDyn](https://github.com/mattEhall/MoorDyn) source code. Because Linux is case sensitive, changing the folder name to have a capital em brakes the `moorDynInput` method of the `mooringClass` class and, therefore, this change is required for the [WEC-Sim_Applications](https://github.com/WEC-Sim/WEC-Sim_Applications) tests to run correctly on GitHub Actions.
