### PR TITLE
Fix .gitignore and .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
-$ cat .gitattributes
 *.* linguist-language=matlab
 *.h5 filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-$ cat .gitignore
-
 # File Extensions
 *~
 *.acn


### PR DESCRIPTION
This PR removes bash scripts from the top of .gitignore and .gitattributes files. Those scripts were placed there probably by a mistake.
Syntax of .gitignore and .gitattributes does not support embedding bash scripts.

This PR is ready to merge