### PR TITLE
Bugfix for Read Capytaine

### DIFF
--- a/source/functions/BEMIO/Read_CAPYTAINE.m
+++ b/source/functions/BEMIO/Read_CAPYTAINE.m
@@ -417,6 +417,10 @@ function [sorted_dofs,inds,reset_tf, nDofs_per_body, split_body_names] = sorted_
 % 2. sort each body's dofs by [standard gbm]: surge, sway, heave, roll, pitch, yaw, gbm1, gbm2, ...
 % 3. concatenate dofs
 
+% Capytaine lowers the case of body names when used in the dof names. Do
+% the same here to parse and reorder dofs correctly.
+body_names = lower(body_names);
+
 % list of standard dofs
 std_dofs = ["surge", "sway", "heave", "roll", "pitch", "yaw"];
 nDofs = length(old_dofs);


### PR DESCRIPTION
This fixes a bug in the BEMIO Read_Capytaine.m function. Part of that function parses dofs to ensure they are in the correct order. Capytaine always uses lower case body names when naming dofs. This PR updates Read_Capytaine to do the same and ensures the dof order is correct.