### PR TITLE
Update documentation on mean drift and current

### DIFF
--- a/docs/theory/theory.rst
+++ b/docs/theory/theory.rst
@@ -101,12 +101,13 @@ as:
 
 .. math::
 
-    m\ddot{X}=F_{exc}(t)+F_{rad}(t)+F_{pto}(t)+F_{v}(t)+F_{me}(t)+F_{B}(t)+F_{m}(t)
+    m\ddot{X}=F_{exc}(t)+F_{md}(t)+F_{rad}(t)+F_{pto}(t)+F_{v}(t)+F_{me}(t)+F_{B}(t)+F_{m}(t)
 
 
 where :math:`\ddot{X}` is the (translational and rotational) acceleration 
 vector of the device, :math:`m` is the mass matrix, :math:`F_{exc}(t)` is the 
-wave excitation force and torque (6-element) vector, :math:`F_{rad}(t)` is the 
+wave excitation force and torque (6-element) vector,  :math:`F_{md}(t)` is the 
+mean drift force and torque vector, :math:`F_{rad}(t)` is the 
 force and torque vector resulting from wave radiation, :math:`F_{pto}(t)` is 
 the PTO force and torque vector, :math:`F_{v}(t)` is the damping force and 
 torque vector, :math:`F_{me}(t)` is the Morison Element force and torque 
@@ -130,7 +131,7 @@ Numerical Methods
 ------------------
 
 WEC-Sim can be used for regular and irregular wave simulations, but note that 
-:math:`F_{exc}(t)` and :math:`F_{rad}(t)` are calculated differently for 
+:math:`F_{rad}(t)` is calculated differently for 
 sinusoidal steady-state response scenarios and random sea simulations. The 
 sinusoidal steady-state response is often used for simple WEC designs with 
 regular incoming waves. However, for random sea simulations or any simulations 
@@ -186,6 +187,14 @@ ramp function, :math:`H` is the wave height, :math:`F_{exc}` is the frequency
 dependent complex wave-excitation amplitude vector, and :math:`\theta` is the 
 wave direction. 
 
+The mean drift force can optionally be included if coefficients are defined in the BEM data. 
+The mean drift force is obtained from
+
+.. math::
+    F_{md}(t)=\left(\frac{H}{2}\right)^2F_{md}(\omega,\theta)
+    
+This force is combined with the excitation force in the response class output.
+
 Convolution Integral Formulation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -226,7 +235,9 @@ where :math:`\phi` is the randomized phase angle and :math:`N` is the number of
 frequency bands selected to discretize the wave spectrum. For repeatable 
 simulation of an irregular wave field :math:`S(\omega)`, WEC-Sim allows 
 specification of :math:`\phi`, refer to the :ref:`user-advanced-features-seeded-phase` 
-section. Additionally, an excitation force impulse response function is defined 
+section. 
+
+Additionally, an excitation force impulse response function is defined 
 as 
 
 .. math::
@@ -234,6 +245,7 @@ as
     K_{e}(t) = \frac{1}{2\pi} \intop_{0-\infty}^{\infty}
                                 F_{exc}(\omega,\theta)e^{i\omega t} d\omega
 
+The excitation impulse response function is only used for the userDefinedElevation wave case.
 
 State Space
 ^^^^^^^^^^^
@@ -710,7 +722,7 @@ formulation for each element on the body can be given as
     F_{me}=\rho\forall\dot{v} + \rho\forall C_{a}(\dot{v}-\ddot{X}) + 
                         \frac{C_{d}\rho A_{d}}{2}(v-\dot{X})|v-\dot{X}|
 
-where :math:`v` is the fluid particle velocity due to wave and current, 
+where :math:`v` is the fluid particle velocity due to the wave and current speed, 
 :math:`C_{a}` is the coefficient of added mass, and :math:`\forall` is the 
 displaced volume. 
 

--- a/docs/user/advanced_features.rst
+++ b/docs/user/advanced_features.rst
@@ -340,6 +340,21 @@ series:
 
     :code:`waves.waveAmpTime<i> = incident wave elevation time series at wave gauge i`
 
+Ocean Current
+^^^^^^^^^^^^^
+The speed of an ocean current can be included through the wave class parameters::
+
+    waves.currentOption
+    waves.currentSpeed
+    waves.currentDirection
+    waves.currentDepth
+
+The current option determines the method used to propagate the surface current across the 
+specified depth. Option 0 is depth independent, option 1 uses a 1/7 power law, option 2
+uses linear variation with depth and option 3 specifies no ocean current. These parameters
+are only used to calculate a more accurate fluid velocity in the Morison Element calculation.
+To incorporate the mean drift force on a body, mean drift coefficients must be input to BEMIO.
+
 .. _user-advanced-features-body:
 
 Body Features

--- a/docs/user/advanced_features.rst
+++ b/docs/user/advanced_features.rst
@@ -611,6 +611,13 @@ For :code:`body(ii).morisonElement.option  = 2` ::
     :code:`body(i).morisonElement.z` is a unit normal vector that defines the 
     orientation of the Morison Element. 
 
+To better represent certain scenarios, an ocean current speed can be defined to 
+calculate a more accurate fluid velocity and acceleration on the Morison 
+Element. These can be defined through the wave class parameters 
+``waves.currentOption``, ``waves.currentSpeed``, ``waves.currentDirection``, 
+and ``waves.currentDepth``. See :ref:`user-advanced-features-wave` for more 
+detail on using these options.
+
 The Morison Element time-step may also be defined as
 :code:`simu.dtME = N*simu.dt`, where N is number of increment steps. For an 
 example application of using Morison Elements in WEC-Sim, refer to the `WEC-Sim 

--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -50,7 +50,7 @@ classdef waveClass<handle
         markerStyle     = 1;        % (`integer`) Marker style, options include: ``1``: Sphere, ``2``: Cube, ``3``: Frame. Default = ``1``: Sphere
         markerSize      = 10;       % (`float`) Marker size in Pixels. Default = ``10``
         currentOption = 3;      % (`integer`) Define the sub-surface current model to be used in WEC-Sim, options include: ``0`` for depth-independent model, ``1`` for 1/7 power law variation with depth, ``2`` for linear variation with depth, or ``3`` for no current. Default = ``3`` 
-        currentSpeed = 0;       % (`float`) Current seed [m/s]. Surface current speed that is uniform along the water column. Default = ``0``
+        currentSpeed = 0;       % (`float`) Current speed [m/s]. Surface current speed that is uniform along the water column. Default = ``0``
         currentDirection = 0;   % (`float`) Current direction [deg]. Surface current direction defined using WEC-Sim global coordinate system. Default = ``0``
         currentDepth = 0;       % (`float`) Current depth [m]. Define the depth over which the sub-surface current is modeled. Must be defined for options ``1`` and ``2``. The current is not calculated for any depths greater than the specified current depth. Default = ``0``
     end    


### PR DESCRIPTION
This PR addresses project card https://github.com/WEC-Sim/WEC-Sim/projects/58#card-72526916
It adds minor doc updates to clarify how/when the mean drift force and waves.current options are used.

To my understanding mean drift and current each have one scenario they affect:
- the mean drift is combined with the excitation force, if coefficients are included in the BEM data
- the current speed is used to calculate a more accurate fluid velocity and acceleration in the Morison Element calculations