### PR TITLE
vectorization of radiationIRF() function

### DIFF
--- a/examples/BEMIO/WAMIT/RM3/bemio.m
+++ b/examples/BEMIO/WAMIT/RM3/bemio.m
@@ -1,8 +1,11 @@
 hydro = struct();
 
 hydro = readWAMIT(hydro,'rm3.out',[]);
+tic
 hydro = radiationIRF(hydro,20,[],[],[],[]);
-hydro = radiationIRFSS(hydro,[],[]);
+toc
+%hydro = radiationIRFSS(hydro,[],[]);
 hydro = excitationIRF(hydro,20,[],[],[],[]);
 writeBEMIOH5(hydro)
-plotBEMIO(hydro)
+
+%plotBEMIO(hydro)

--- a/examples/BEMIO/WAMIT/RM3/bemio.m
+++ b/examples/BEMIO/WAMIT/RM3/bemio.m
@@ -1,11 +1,8 @@
 hydro = struct();
 
 hydro = readWAMIT(hydro,'rm3.out',[]);
-tic
 hydro = radiationIRF(hydro,20,[],[],[],[]);
-toc
-%hydro = radiationIRFSS(hydro,[],[]);
+hydro = radiationIRFSS(hydro,[],[]);
 hydro = excitationIRF(hydro,20,[],[],[],[]);
 writeBEMIOH5(hydro)
-
-%plotBEMIO(hydro)
+plotBEMIO(hydro)

--- a/source/functions/BEMIO/excitationIRF.m
+++ b/source/functions/BEMIO/excitationIRF.m
@@ -28,7 +28,7 @@ if isempty(wMax)==1;  wMax = max(hydro.w);  end
 % Interpolate to the given t and w
 t = linspace(-tEnd,tEnd,nDt);
 w = linspace(wMin,wMax,nDw);  
-N = length(t)*sum(hydro.dof)*hydro.Nh;
+N = sum(hydro.dof)*hydro.Nh;
 
 % Calculate the impulse response function for excitation
 n = 0;
@@ -36,7 +36,7 @@ for i = 1:sum(hydro.dof)
     for j = 1:hydro.Nh
         ex_re = interp1(hydro.w,squeeze(hydro.ex_re(i,j,:)),w);
         ex_im = interp1(hydro.w,squeeze(hydro.ex_im(i,j,:)),w);
-        hydro.ex_K(i,j,:) = (1/pi)*trapz(w,ex_re.*cos(w*t(:))-ex_im.*sin(w.*t(:)),2);
+        hydro.ex_K(i,j,:) = (1/pi)*trapz(w,ex_re.*cos(w.*t(:))-ex_im.*sin(w.*t(:)),2);
         n = n+1;
     end
     waitbar(n/N)

--- a/source/functions/BEMIO/excitationIRF.m
+++ b/source/functions/BEMIO/excitationIRF.m
@@ -32,14 +32,12 @@ N = length(t)*sum(hydro.dof)*hydro.Nh;
 
 % Calculate the impulse response function for excitation
 n = 0;
-for k = 1:length(t)
-    for i = 1:sum(hydro.dof)
-        for j = 1:hydro.Nh
-            ex_re = interp1(hydro.w,squeeze(hydro.ex_re(i,j,:)),w);
-            ex_im = interp1(hydro.w,squeeze(hydro.ex_im(i,j,:)),w);
-            hydro.ex_K(i,j,k) = (1/pi)*trapz(w,ex_re.*cos(w*t(k))-ex_im.*sin(w*t(k)));
-            n = n+1;
-        end
+for i = 1:sum(hydro.dof)
+    for j = 1:hydro.Nh
+        ex_re = interp1(hydro.w,squeeze(hydro.ex_re(i,j,:)),w);
+        ex_im = interp1(hydro.w,squeeze(hydro.ex_im(i,j,:)),w);
+        hydro.ex_K(i,j,:) = (1/pi)*trapz(w,ex_re.*cos(w*t(:))-ex_im.*sin(w.*t(:)),2);
+        n = n+1;
     end
     waitbar(n/N)
 end

--- a/source/functions/BEMIO/radiationIRF.m
+++ b/source/functions/BEMIO/radiationIRF.m
@@ -28,25 +28,19 @@ if isempty(wMax)==1;  wMax = max(hydro.w);  end
 % Interpolate to the given t and w
 t = linspace(0,tEnd,nDt);
 w = linspace(wMin,wMax,nDw);
-% N = length(t)*sum(hydro.dof)*sum(hydro.dof);
 N = sum(hydro.dof) * sum(hydro.dof);
 
 % Calculate the impulse response function for radiation
 n = 0;
-
 hydro.ra_K = nan(sum(hydro.dof), sum(hydro.dof), length(t));
-
 for i = 1:sum(hydro.dof)
     for j = 1:sum(hydro.dof)
         ra_B = interp1(hydro.w,squeeze(hydro.B(i,j,:)),w);
         hydro.ra_K(i,j,:) = (2/pi)*trapz(w,ra_B.*(cos(w.*t(:)).*w), 2);
-        % hydro.ra_L(i,j,k) = (2/pi)*trapz(w,ra_B.*(sin(w*t(k))));  %Not used
         n = n+1;
     end
     waitbar(n/N)
 end
-
-
 
 % Calculate the infinite frequency added mass
 ra_Ainf_temp = zeros(length(hydro.w),1);                                    %Initialize the variable

--- a/source/functions/BEMIO/radiationIRF.m
+++ b/source/functions/BEMIO/radiationIRF.m
@@ -28,21 +28,25 @@ if isempty(wMax)==1;  wMax = max(hydro.w);  end
 % Interpolate to the given t and w
 t = linspace(0,tEnd,nDt);
 w = linspace(wMin,wMax,nDw);
-N = length(t)*sum(hydro.dof)*sum(hydro.dof);
+% N = length(t)*sum(hydro.dof)*sum(hydro.dof);
+N = sum(hydro.dof) * sum(hydro.dof);
 
 % Calculate the impulse response function for radiation
 n = 0;
-for k = 1:length(t)
-    for i = 1:sum(hydro.dof)
-        for j = 1:sum(hydro.dof)
-            ra_B = interp1(hydro.w,squeeze(hydro.B(i,j,:)),w);
-            hydro.ra_K(i,j,k) = (2/pi)*trapz(w,ra_B.*(cos(w*t(k)).*w));
-            % hydro.ra_L(i,j,k) = (2/pi)*trapz(w,ra_B.*(sin(w*t(k))));  %Not used
-            n = n+1;
-        end
+
+hydro.ra_K = nan(sum(hydro.dof), sum(hydro.dof), length(t));
+
+for i = 1:sum(hydro.dof)
+    for j = 1:sum(hydro.dof)
+        ra_B = interp1(hydro.w,squeeze(hydro.B(i,j,:)),w);
+        hydro.ra_K(i,j,:) = (2/pi)*trapz(w,ra_B.*(cos(w.*t(:)).*w), 2);
+        % hydro.ra_L(i,j,k) = (2/pi)*trapz(w,ra_B.*(sin(w*t(k))));  %Not used
+        n = n+1;
     end
     waitbar(n/N)
 end
+
+
 
 % Calculate the infinite frequency added mass
 ra_Ainf_temp = zeros(length(hydro.w),1);                                    %Initialize the variable


### PR DESCRIPTION
hat tip to @crobarcro for originally implementing this improvement in RenewNet

trapz function used in B(w) cosine transformation now applied to whole arrays rather than iteratively within the k'th loop (ie over IRF time)

initial tests with RM3 show 60% reduction in RIRF computation time