### PR TITLE
Fix readBEMIOH5 bug not creating gbm structure

### DIFF
--- a/source/functions/BEMIO/readBEMIOH5.m
+++ b/source/functions/BEMIO/readBEMIOH5.m
@@ -58,7 +58,11 @@ try hydroData.hydro_coeffs.radiation_damping.state_space.C.all = reverseDimensio
 try hydroData.hydro_coeffs.radiation_damping.state_space.D.all = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/radiation_damping/state_space/D/all'])); end
 
 % Read GBM parameters if available
-try 
+try
+    
+    dof_start = hydroData.properties.dof_start;
+    dof_end   = hydroData.properties.dof_end;
+
     tmp_mass = reverseDimensionOrder(h5read(filename, [h5BodyName '/properties/mass']));
     hydroData.gbm.mass = tmp_mass(dof_start+6:dof_end,dof_start+6:dof_end);
 
@@ -68,6 +72,7 @@ try
     tmp_damping = reverseDimensionOrder(h5read(filename, [h5BodyName '/properties/damping']));
     hydroData.gbm.damping = tmp_damping(dof_start+6:dof_end,dof_start+6:dof_end);
     clear tmp_mass tmp_stiffness tmp_damping;
+
 end
 
 % Read mean drift coefficients if available


### PR DESCRIPTION
This PR fixes a bug in the `readBEMIOH5` function where the creation of the `gbm` structure was being skipped. This is because the variables `dof_start` and `dof_end` were not defined.

In general, the use of `try` blocks without a `catch` is not good practice. As in this case, any error will pass and go unhanded until it breaks something downstream. Consider handling the errors that are expected rather than silently passing on any issues.