### PR TITLE
Add Google Analytics 4

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,13 @@
+{% extends "!layout.html" %}
+{% block extrahead %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BSPTGP3DXP"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-BSPTGP3DXP');
+    </script>
+    {{super}}
+{% endblock %}


### PR DESCRIPTION
Our current website analytics, Universal Analytics, is being depreciating in 2023. To begin tracking web usage we need to upgrade to Google Analytics 4. 

Google cannot convert tags automatically because this was set-up a few years ago with a format that is now outdated (``analytics.js`` instead of ``gtag.js``). Also, we don't want to remove the old analytics yet until both are working, so I cannot simply change the ID in ``conf.py``:

    html_theme_options = {
        'analytics_id': 'UA-XXXXXXXXXXX'
    }

So, we must manually add new tags into the docs compilation process. I extended the sphinx_rtd_theme layout to include custom HTML. This will append a code block to each ``.html`` file's header that will connect pages with our new analytics stream. 


Ready for review, but leaving as a draft since this will not go into v5.0