### PR TITLE
Remove fixed mass option

### DIFF
--- a/docs/user/advanced_features.rst
+++ b/docs/user/advanced_features.rst
@@ -385,6 +385,11 @@ following features are available:
   displaced volume contained in the ``*.h5`` file. If :code:`simu.nonlinearHydro = 1` 
   or :code:`simu.nonlinearHydro = 2`, then the mass is calculated using the displaced 
   volume of the provided STL geometry file.
+  
+* **Fixed Body** - if a body is fixed to the seabed, the mass and moment of inertia 
+  may be set to arbitrary values such as 999 kg and [999 999 999] kg-m^2. If the 
+  constraint forces on the fixed body are important, the mass and inertia must instead 
+  be set to their real values.
 
 * **Import STL** - to read in the geometry (``*.stl``) into Matlab use the 
   :code:`body(i).importBodyGeometry()` method in the bodyClass. This method will import the 

--- a/docs/user/advanced_features.rst
+++ b/docs/user/advanced_features.rst
@@ -386,10 +386,10 @@ following features are available:
   or :code:`simu.nonlinearHydro = 2`, then the mass is calculated using the displaced 
   volume of the provided STL geometry file.
   
-* **Fixed Body** - if a body is fixed to the seabed, the mass and moment of inertia 
-  may be set to arbitrary values such as 999 kg and [999 999 999] kg-m^2. If the 
-  constraint forces on the fixed body are important, the mass and inertia must instead 
-  be set to their real values.
+* **Fixed Body** - if a body is fixed to the seabed using a fixed constraint, the mass 
+  and moment of inertia may be set to arbitrary values such as 999 kg and [999 999 999] 
+  kg-m^2. If the constraint forces on the fixed body are important, the mass and inertia 
+  should be set to their real values.
 
 * **Import STL** - to read in the geometry (``*.stl``) into Matlab use the 
   :code:`body(i).importBodyGeometry()` method in the bodyClass. This method will import the 

--- a/docs/user/advanced_features.rst
+++ b/docs/user/advanced_features.rst
@@ -386,10 +386,6 @@ following features are available:
   or :code:`simu.nonlinearHydro = 2`, then the mass is calculated using the displaced 
   volume of the provided STL geometry file.
 
-* **Fixed Body** - if the mass is unknown (or not important to the dynamics), 
-  the user may specify :code:`body(i).mass = 'fixed'` which will set the mass 
-  to 999 kg and moment of inertia to [999 999 999] kg-m^2.
-
 * **Import STL** - to read in the geometry (``*.stl``) into Matlab use the 
   :code:`body(i).importBodyGeometry()` method in the bodyClass. This method will import the 
   mesh details (vertices, faces, normals, areas, centroids) into the 

--- a/examples/OSWEC/wecSimInputFile.m
+++ b/examples/OSWEC/wecSimInputFile.m
@@ -46,8 +46,8 @@ body(1).inertia = [1.85e6 1.85e6 1.85e6];       % Moment of Inertia [kg-m^2]
 % Base
 body(2) = bodyClass('hydroData/oswec.h5');      % Initialize bodyClass for Base
 body(2).geometryFile = 'geometry/base.stl';     % Geometry File
-body(2).mass = 999;                             % Fixed Body Mass
-body(2).inertia = [999 999 999];                % Fixed Body Inertia
+body(2).mass = 999;                             % Placeholder mass for a fixed body
+body(2).inertia = [999 999 999];                % Placeholder inertia for a fixed body
 
 %% PTO and Constraint Parameters
 % Fixed

--- a/examples/OSWEC/wecSimInputFile.m
+++ b/examples/OSWEC/wecSimInputFile.m
@@ -46,7 +46,8 @@ body(1).inertia = [1.85e6 1.85e6 1.85e6];       % Moment of Inertia [kg-m^2]
 % Base
 body(2) = bodyClass('hydroData/oswec.h5');      % Initialize bodyClass for Base
 body(2).geometryFile = 'geometry/base.stl';     % Geometry File
-body(2).mass = 'fixed';                         % Creates Fixed Body
+body(2).mass = 999;                             % Fixed Body Mass
+body(2).inertia = [999 999 999];                % Fixed Body Inertia
 
 %% PTO and Constraint Parameters
 % Fixed

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -79,7 +79,7 @@ classdef bodyClass<handle
     properties (SetAccess = 'private', GetAccess = 'public')% internal
         b2bDOF              = []                            % (`matrix`) Matrices length, Options: ``6`` without body-to-body interactions. ``6*number of hydro bodies`` with body-to-body interactions.
         hydroForce          = struct()                      % (`structure`) Defines hydrodynamic forces and coefficients used during simulation.
-        massCalcMethod      = []                            % (`string`) Method used to obtain mass, options: ``'user'``, ``'fixed'``, ``'equilibrium'``
+        massCalcMethod      = []                            % (`string`) Method used to obtain mass, options: ``'user'``, ``'equilibrium'``
         number              = []                            % (`integer`) Body number, must be the same as the BEM body number.
         total               = []                            % (`integer`) Total number of hydro bodies         
     end
@@ -125,11 +125,11 @@ classdef bodyClass<handle
                 error('The hdf5 file %s does not exist',obj.h5File)
             end
             % Check definitions
-            if (~isnumeric(obj.mass) && ~strcmp(obj.mass, 'equilibrium') && ~strcmp(obj.mass, 'fixed')) || isempty(obj.mass)
-                error('Body mass needs to be defined numerically, set to ''equilibrium'', or set to ''fixed''.')
+            if (~isnumeric(obj.mass) && ~strcmp(obj.mass, 'equilibrium')) || isempty(obj.mass)
+                error('Body mass needs to be defined numerically, set to ''equilibrium''.')
             end
-            if isempty(obj.inertia) && ~strcmp(obj.mass, 'fixed')
-                error('Body moment of inertia needs to be defined for all non-fixed bodies.')
+            if isempty(obj.inertia)
+                error('Body moment of inertia needs to be defined for all bodies.')
             end
             if strcmp(explorer, 'on') %if mechanics explorer is set to on
                 % Check geometry file
@@ -188,7 +188,7 @@ classdef bodyClass<handle
             elseif obj.nonHydro>0
                 % This method checks WEC-Sim user inputs for each drag or non-hydro
                 % body and generates error messages if parameters are not properly defined for the bodyClass.
-                if ~isnumeric(obj.mass) && ~isequal(obj.mass,'equilibrium') && ~isequal(obj.mass, 'fixed')
+                if ~isnumeric(obj.mass) && ~isequal(obj.mass,'equilibrium')
                     error('Body mass needs to be defined numerically for non-hydro or drag bodies')
                 end
                 if ~isnumeric(obj.inertia)
@@ -232,7 +232,7 @@ classdef bodyClass<handle
         function nonHydroForcePre(obj,rho)
             % nonHydro Pre-processing calculations
             % Similar to dragForcePre, but only adjusts the mass for cases 
-            % using 'fixed' or 'equilibrium' 
+            % using 'equilibrium' 
             obj.setMassMatrix(rho);
         end
         
@@ -753,10 +753,6 @@ classdef bodyClass<handle
                 else
                     obj.mass = obj.volume * rho;
                 end
-            elseif strcmp(obj.mass, 'fixed')
-                obj.massCalcMethod = obj.mass;
-                obj.mass = 999;
-                obj.inertia = [999 999 999];
             else
                 obj.massCalcMethod = 'user';
             end

--- a/tutorials/OSWEC/OSWEC_wecSimInputFile.m
+++ b/tutorials/OSWEC/OSWEC_wecSimInputFile.m
@@ -22,7 +22,8 @@ body(1).inertia = [1.85e6 1.85e6 1.85e6];  % Moment of Inertia [kg-m^2]
 % Base
 body(2) = bodyClass('hydroData/oswec.h5');      % Initialize bodyClass for Base
 body(2).geometryFile = 'geometry/base.stl';     % Geometry File
-body(2).mass = 'fixed';                         % Creates Fixed Body
+body(2).mass = 999;                             % Fixed Body Mass
+body(2).inertia = [999 999 999];                % Fixed Body Inertia
 
 %% PTO and Constraint Parameters
 % Fixed

--- a/tutorials/OSWEC/wecSimInputFile.m
+++ b/tutorials/OSWEC/wecSimInputFile.m
@@ -22,7 +22,8 @@ body(1).inertia = [1.85e6 1.85e6 1.85e6];  % Moment of Inertia [kg-m^2]
 % Base
 body(2) = bodyClass('hydroData/*.h5');          % Initialize bodyClass for Base
 body(2).geometryFile = 'geometry/base.stl';     % Location of Geomtry File
-body(2).mass = 'fixed';                         % Creates Fixed Body
+body(2).mass = 999;                             % Fixed Body Mass
+body(2).inertia = [999 999 999];                % Fixed Body Inertia
 
 %% PTO and Constraint Parameters
 % Fixed

--- a/tutorials/OSWEC/wecSimInputFile.m
+++ b/tutorials/OSWEC/wecSimInputFile.m
@@ -22,8 +22,8 @@ body(1).inertia = [1.85e6 1.85e6 1.85e6];  % Moment of Inertia [kg-m^2]
 % Base
 body(2) = bodyClass('hydroData/*.h5');          % Initialize bodyClass for Base
 body(2).geometryFile = 'geometry/base.stl';     % Location of Geomtry File
-body(2).mass = 999;                             % Fixed Body Mass
-body(2).inertia = [999 999 999];                % Fixed Body Inertia
+body(2).mass = 999;                             % Placeholder mass for a fixed body
+body(2).inertia = [999 999 999];                % Placeholder inertia for a fixed body
 
 %% PTO and Constraint Parameters
 % Fixed


### PR DESCRIPTION
[Project card ](https://github.com/WEC-Sim/WEC-Sim/projects/58#card-79563001)

The bodyClass fixed mass option can be somewhat misleading if there is not actually a fixed constraint. If the body isn't fixed it will likely sink indefinitely and become unphysical. Also, if a fixed constraint is connected to the body, ``body.mass='fixed'`` is not required and its mass doesn't affect the simulation.

This PR removes the ``body.mass='fixed'`` option, the associated logic, and a small related section in the documentation. For after v5.0
