### PR TITLE
wecSimPCT Fix (Master)

### DIFF
--- a/source/functions/initializeWecSim.m
+++ b/source/functions/initializeWecSim.m
@@ -28,11 +28,18 @@ diary('simulation.log')
 %% Add 'temp' directory
 % Store root directory of this *.m file
 projectRootDir = pwd;
+if exist('pctDir')
+    projectRootDir = [projectRootDir filesep pctDir];
+end
 
 % Create 'temp' directory if it doesn't exist and add to 'temp' path
 warning('off','MATLAB:MKDIR:DirectoryExists')
-if mkdir('temp') == 0
-    mkdir 'temp'
+if exist('pctDir')
+    mkdir ([pctDir filesep 'temp'])
+else
+    if mkdir('temp') == 0
+        mkdir 'temp'
+    end
 end
 addpath(fullfile(projectRootDir,'temp'),'-end');
 

--- a/source/functions/stopWecSim.m
+++ b/source/functions/stopWecSim.m
@@ -52,10 +52,8 @@ if simu.saveWorkspace==1
     if exist('pctDir') 
         filename = sprintf('savedData%03d.mat', imcr);
         copyfile(outputFile,['../' filename])
+        cd (['..' filesep pctDir filesep '..' filesep]);
     end
-end
-if exist('pctDir')
-    cd (['..' filesep pctDir filesep '..' filesep]); 
 end
 
 %% Remove 'temp' directory

--- a/source/wecSimPCT.m
+++ b/source/wecSimPCT.m
@@ -104,12 +104,13 @@ parfor imcr=1:length(mcr.cases(:,1))
     t = getCurrentTask();
     filename = sprintf('savedLog%03d.txt', t.ID);
     pctDir = sprintf('pctDir_%g', t.ID);
-    mkdir(pctDir) 
+    getAttachedFilesFolder(pctDir);
     fileID = fopen(filename,'a');
     fprintf(fileID,'wecSimPCT Case %g/%g on Worker Number %g/%g \n',imcr,length(mcr.cases(:,1)),t.ID,totalNumOfWorkers);
     % Run WEC-Sim
     wecSimFcn(imcr,mcr,pctDir,totalNumOfWorkers);   
     fclose(fileID);
+    rmdir(pctDir, 's')    
 end
 
 clear imcr totalNumOfWorkers


### PR DESCRIPTION
Fixed a few bugs, which cause WEC-Sim to crash when running wecSimPCT:
- "initializeWecSim.m": Change the project directory and move the "temp" inside the pctDir folder so that each WEC-Sim run won't interfere.
-  "stopWecSim.m": Move the command cd (['..' filesep pctDir filesep '..' filesep]); inside the "if simu.saveWorkspace==1" if loop. The command is only needed when WEC-Sim writes out the output file.
-  "wecSimPCT.m" :  Remove the pctDirs after the simulation.