### PR TITLE
[WAMIT] Defining the COG using XCG and not XBODY

### DIFF
--- a/source/functions/BEMIO/readWAMIT.m
+++ b/source/functions/BEMIO/readWAMIT.m
@@ -117,6 +117,9 @@ for n = 1:N
             end
             if T==2
                 hydro(F).A(tmp{1}(1),tmp{1}(2),hydro(F).Nf) = tmp{1}(3);  % Added mass
+                if exist('hydro(F).Ainf(tmp{1}(1),tmp{1}(2))') == 0
+                    hydro(F).Ainf(tmp{1}(1),tmp{1}(2)) = hydro(F).A(tmp{1}(1),tmp{1}(2),end);
+                end
                 hydro(F).B(tmp{1}(1),tmp{1}(2),hydro(F).Nf) = tmp{1}(4);  % Radiation damping
             end
             i = i+1;

--- a/source/functions/BEMIO/readWAMIT.m
+++ b/source/functions/BEMIO/readWAMIT.m
@@ -69,18 +69,20 @@ for n = 1:N
         tmp = textscan(raw{n},'%s %s %f %s %s %f','TreatAsEmpty',{'infinite'},'EmptyValue',Inf);
         hydro(F).h = tmp{3};  % Water depth
     end
-    if isempty(strfind(raw{n},' Center of Gravity  (Xg,Yg,Zg):'))==0
+    if isempty(strfind(raw{n},'XBODY ='))==0
         hydro(F).Nb = hydro(F).Nb+1;
         tmp = textscan(raw{n},'%s %s %f %s %s %f %s %s %f %s %s %f');
-        hydro(F).cg(:,hydro(F).Nb) = [tmp{3} tmp{6} tmp{9}];  % Center of gravity
+        hydro(F).bodyFrame(:,hydro(F).Nb) = [tmp{3} tmp{6} tmp{9}];  % Center of Body Frame
     end
     if isempty(strfind(raw{n},'Volumes (VOLX,VOLY,VOLZ):'))==0
         tmp = textscan(raw{n}(find(raw{n}==':')+1:end),'%f');
         hydro(F).Vo(hydro(F).Nb) = median(tmp{:});  % Displacement volume
     end
     if isempty(strfind(raw{n},'Center of Buoyancy (Xb,Yb,Zb):'))==0
-        tmp = textscan(raw{n}(find(raw{n}==':')+1:end),'%f');
-        hydro(F).cb(:,hydro(F).Nb) = hydro(F).cg(:,hydro(F).Nb) + tmp{1};  % Center of buoyancy
+        hydro(F).cb(:,hydro(F).Nb) = cell2mat( textscan(raw{n}(find(raw{n}==':')+1:end),'%f'));  % Center of buoyancy
+    end
+    if isempty(strfind(raw{n},'(Xg,Yg,Zg):'))==0
+        hydro(F).cg(:,hydro(F).Nb) = cell2mat( textscan(raw{n}(find(raw{n}==':')+1:end),'%f'));
     end
     if isempty(strfind(raw{n},'Hydrostatic and gravitational'))==0
         hydro(F).Khs(:,:,hydro(F).Nb) = zeros(6,6);  % Linear restoring stiffness

--- a/source/functions/BEMIO/readWAMIT.m
+++ b/source/functions/BEMIO/readWAMIT.m
@@ -69,7 +69,7 @@ for n = 1:N
         tmp = textscan(raw{n},'%s %s %f %s %s %f','TreatAsEmpty',{'infinite'},'EmptyValue',Inf);
         hydro(F).h = tmp{3};  % Water depth
     end
-    if isempty(strfind(raw{n},'XBODY ='))==0
+    if isempty(strfind(raw{n},' Center of Gravity  (Xg,Yg,Zg):'))==0
         hydro(F).Nb = hydro(F).Nb+1;
         tmp = textscan(raw{n},'%s %s %f %s %s %f %s %s %f %s %s %f');
         hydro(F).cg(:,hydro(F).Nb) = [tmp{3} tmp{6} tmp{9}];  % Center of gravity

--- a/source/functions/BEMIO/writeBEMIOH5.m
+++ b/source/functions/BEMIO/writeBEMIOH5.m
@@ -72,8 +72,13 @@ for i = 1:hydro.Nb
 
     % Write added mass coefficients
     m_add = m_add + m;
-    writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/added_mass/inf_freq'],permute(hydro.Ainf((n+1):(n+m),:),[2 1]),'Infinite frequency added mass','kg');
+   
     writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/added_mass/all'],permute(hydro.A((n+1):(n+m),:,:),[3 2 1]),'Added mass','kg-m^2 (rotation); kg (translation)');
+    try
+         writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/added_mass/inf_freq'],permute(hydro.Ainf((n+1):(n+m),:),[2 1]),'Infinite frequency added mass','kg');
+    catch
+        writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/added_mass/all'],permute(hydro.A((n+1):(n+m),:,end),[3 2 1]),'Added mass','kg-m^2 (rotation); kg (translation)');
+    end
     
     % Write excitation coefficients and IRF
     writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/excitation/im'],permute(hydro.ex_im((n+1):(n+m),:,:),[3 2 1]),'Imaginary component of excitation force','');


### PR DESCRIPTION
This PR modifies the readWAMIT.m script such that,
1. A new variable bodyFrame stores the XBODY,
2. The Center of Buoyancy is not simply equated to XBODY but extracted from the Center of Buoyancy information in the WAMIT .out file,
3. The Center of Gravity is populated using the XCG information.

The WEC-Sim models shall have the same body positions, CoG, and response, if the .gdf files are written to represent the CoG with respect to the Global Origin, such that,
$CoG = \vec{XBODY} + \vec{XCG}$

This implies that the .gdf files with NOT written by compulsorily assigning the XCG to be $[0,0,0]$. 

Investigation using WAMIT runs suggests that the hydrostatics calculations in WAMIT use the XCG and are agnostic to XBODY location. And if the hydrostatics are being calculated solely based on the XCG location, forcing it to $[0,0,0]$ will also force the water-line across a plane that has no correlation with the actual hydrostatics.

The motivation to do this is,
a. Accurate calculation of hydrostatics,
b. To be able to calculate hydrostatics for bodies floating at a `final' equilibrium that not equal to their free-floating equilibrium position due to,
          i. Mass density of body < Mass density of water,
          ii. External forces modifying the hydrostatic equilibrium, eg. pre-tensioned devices,
 c. To be able to use the same .gdf files across WAMIT, NEMOH, and CAPYTAINE 
d. To correctly assign the Center of Buoyancy.

Recently, I sent @nathanmtom a more detailed discussion. Here follows the discussion on the motivations for modifying the workflow.


The center of buoyancy and hydrostatics are calculated using the body frame, i.e., XBODY, and not the XCG. This has significant implications when an external mass matrix is defined. The calculations for the pitch hydrostatic coefficient, K_55, use, 
	Second Moment of Area, $\rho g \iint_{S_b}x^2dS$,
	Center of Buoyancy, $z_b$,
	Center of Gravity, $z_g$.
If the center of buoyancy and gravity is calculated with respect to the body frame, translating the XBODY variable will be wrong. It can be checked from the wamit runs, that the hydrostatic stiffness of runs where the XBODY was transposed, and where the XCG was transposed can be different , although the final location of the bodies might be same.


Currently the WEC-Sim manual prescribes that the XCG should be kept zero and XBODY should be moved around, in such a way such that, the XCG is $[0, 0, 0]$. The hydrostatic coefficients in the pitch mode and the couplings thereof, however, require the mass of the body, which may be different than the mass of the displaced fluid. This will be correct if the XCG at $[0, 0, 0]$ was indeed the hydrostatic equilibrium. Pre-tensioned floating bodies, however, have their final hydrostatic equilibrium at a point different than the free-floating hydrostatic equilibrium of such a floating body. 

![image](https://user-images.githubusercontent.com/84348506/172762545-fca48f34-5f8a-455d-82f7-901fad6c5657.png)


The problem especially emerges when the hydrodynamic coefficients calculated when the floating body is at a point that is different than the free-floating hydrostatic equilibrium. Manipulating the gdf file to have the floating body’s center of gravity at $[0, 0, 0]$ is a prudent approach to avoid the off-diagonal inertia terms. This manipulation is however misleading for pre-tensioned floating bodies. The hydrodynamic coefficients for pre-tensioned floating bodies should be calculated at the ‘final’ equilibrium. By the ‘final’ equilibrium I mean the hydrostatic equilibrium after external constraints have been applied. To state more directly, for pre-tensioned floating bodies the gdf files should be manipulated to have their origin (with respect to the XBODY frame) based on the immersed wetted area at the ‘final equilibrium’ and not the free-floating XCG or transposing the floating body such that the XCG is at $[0, 0, 0]$. This would then allow for a non-zero XCG, thereby incorporating the modified hydrostatic forces at the equilibrium position due to the pre-tension forces, i.e., the mzg can contribute to the hydrostatic coefficient in pitch mode. Currently, the $mz_g$ term would always be equal to zero because the XCG is forced to be zero.
 

The WEC-Sim models assign the center of gravity of the body() object based on the XBODY. While modelling pre-tensioned floating bodies, WEC-Sim models as of now would not represent the ‘final’ equilibrium. Which might in fact aid the modelling process by accounting for the effect of pre-tension forces on the hydrostatic equilibrium. To summarize, when modelling pre-tensioned floating bodies, the .gdf files should have their origin at the position where the floating body would be in hydrostatic equilibrium after the pre-tension forces have moved the body to the final hydrostatic equilibrium. The standard practice should be to have the .gdf file written assuming the body is at hydrostatic equilibrium, such that the .gdf file contains the immersed wetted surface at hydrostatic equilibrium – the ‘final’ hydrostatic equilibrium. This implies that the XBODY needn’t be defined by requiring the origin of the .gdf file coincident with XCG. The XBODY could be defined at any arbitrary location, since the XCG is defined with respect to the XBODY, and therefore the BEM calculations should not be affected, as long as the .gdf file was written such that the immersed wetted surface corresponds to the hydrostatic equilibrium.

The BEMIO routine should therefore not constrain the .gdf files to have their XCG at $[0, 0, 0]$, while being agnostic to the hydrostatic equilibrium. For cases primarily concerned with translational modes, having the XCG at $[0, 0, 0]$ is rather convenient because then BEMIO then can only use the XBODY variable. However, this manipulation is agnostic to the hydrostatic equilibrium. For cases where at hydrostatic equilibrium the XCG happens to be at $[0, 0, 0]$, it would be business as usual, but for cases where the .gdf file is transposed to have their XCG at $[0, 0, 0]$, while the immersed volume does not represent the hydrostatic equilibrium the $ρ∀g-mz_g$ term would be incorrect because the moment arm this term represents would be agnostic of the hydrostatic equilibrium.  Therefore, all of these issues will be resolved if BEMIO can populate the center of gravity information by using both the XBODY and the XCG when the floating body is at hydrostatic equilibrium and not just simply requiring the XCG at $[0, 0, 0]$. This change may not have much consequence if the body’s mass distribution can be approximated with the density equivalent to that of water but would be problematic for rotational modes and bodies with lower densities kept at equilibrium with contributions from external forces and moments. Being cognizant of the hydrostatic equilibrium would allow the BEM runs to correctly represent the hydrostatic coefficients.
