### PR TITLE
Fix readCAPYTAINE

### DIFF
--- a/source/functions/BEMIO/readCAPYTAINE.m
+++ b/source/functions/BEMIO/readCAPYTAINE.m
@@ -88,6 +88,15 @@ tmp = ncread(filename,'body_name')';
 for i=1:s1
     hydro(F).body{i} = erase(tmp(i,:), char(0)); % assign preliminary value to body names
 end
+
+hydro(F).body = hydro(F).body{:};
+% Check for newer formatting
+if isstring(hydro(F).body)
+    ncFormat = 'new';
+else 
+    ncFormat = 'old';
+end
+
 hydro(F).body = split(hydro(F).body,'+');
 
 % sort radiating dof into standard list if necessary
@@ -118,14 +127,26 @@ end
 %% Reorder dofs if needed
 % check the ordering of the 'complex' dimension
 tmp = ncread(filename,'complex')';
-if tmp(1,:) == "re" && tmp(2,:) == "im"
-    i_re = 1;
-    i_im = 2;
-elseif tmp(1,:) == "im" && tmp(2,:) == "re"
-    i_im = 1;
-    i_re = 2;
-else
-    error('Error:BEMIO:Read_Capytaine: check complex dimension indices');
+if ncFormat == 'new'
+    if tmp(:,1) == "re" && tmp(:,2) == "im"
+        i_re = 1;
+        i_im = 2;
+    elseif tmp(:,1) == "im" && tmp(:,2) == "re"
+        i_im = 1;
+        i_re = 2;
+    else
+        error('Error:BEMIO:Read_Capytaine: check complex dimension indices');
+    end
+elseif ncFormat == 'old'
+    if tmp(1,:) == "re" && tmp(2,:) == "im"
+        i_re = 1;
+        i_im = 2;
+    elseif tmp(1,:) == "im" && tmp(2,:) == "re"
+        i_im = 1;
+        i_re = 2;
+    else
+        error('Error:BEMIO:Read_Capytafe: check complex dimension indices');
+    end
 end
 
 % Check that radiating & influenced dofs are same length and at least 6*Nb


### PR DESCRIPTION
This PR addresses issue #875. The issue has 2 parts:

1. Body name string vs. cell array formatting

- Old .nc files have body names formatted as strings while new ones have body names formatted as cell arrays
- Fix: The simple fix for this is to unpack each element of the body names.

2. Complex indices format

- Old .nc files have horizontal vectors of for specifying order of the complex dimension, while new ones have vertical vectors.
- Fix: Check whether name is a string to check version, and read in order of the complex dimension based on new vs. old version.