### PR TITLE
Fix wave elevation import with rampTime = 0

### DIFF
--- a/source/functions/simulink/model/irregWaveMorison.m
+++ b/source/functions/simulink/model/irregWaveMorison.m
@@ -38,7 +38,7 @@ for ii = 1:rr
             currentSpeedDepth = 0;
     end
     % Ramp Time
-    if Time <= rampTime
+    if Time < rampTime
         curramp        = currentSpeedDepth*(1 + cos(pi + pi/rampTime*Time))/2;
     else
         curramp        = currentSpeedDepth;
@@ -69,7 +69,7 @@ for ii = 1:rr
             coeffVert  = sinh(kz + kh)/cosh(kh);
         end
         % Ramp Time
-        if Time <= rampTime
+        if Time < rampTime
             ramp        = (sqrt(A(jj,1)*dw(jj,1))/2)*(1 + cos(pi + pi/rampTime*Time));
         else
             ramp        = sqrt(A(jj,1)*dw(jj,1));

--- a/source/functions/simulink/model/noWaveMorison.m
+++ b/source/functions/simulink/model/noWaveMorison.m
@@ -36,7 +36,7 @@ for ii = 1:rr
             currentSpeedDepth = 0;
     end
     % Ramp Time
-    if Time <= rampTime
+    if Time < rampTime
         curramp        = currentSpeedDepth*(1 + cos(pi + pi/rampTime*Time))/2;
     else
         curramp        = currentSpeedDepth;

--- a/source/functions/simulink/model/regWaveMorison.m
+++ b/source/functions/simulink/model/regWaveMorison.m
@@ -37,7 +37,7 @@ for ii = 1:rr
             currentSpeedDepth = 0;
     end
     % Ramp Time
-    if Time <= rampTime
+    if Time < rampTime
         curramp     = currentSpeedDepth*(1 + cos(pi + pi/rampTime*Time))/2;
     else
         curramp     = currentSpeedDepth;
@@ -64,7 +64,7 @@ for ii = 1:rr
         coeffVert   = sinh(kz + kh)/cosh(kh);
     end
     % Ramp Time
-    if Time <= rampTime
+    if Time < rampTime
         ramp        = (A/2)*(1 + cos( pi + pi/rampTime*Time));
     else
         ramp        = A;

--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -570,7 +570,7 @@ classdef waveClass<handle
             % Used by postProcess for variable step solvers
             maxIt = length(timeseries);
             rampFunction = (1+cos(pi+pi*timeseries/rampTime))/2;
-            rampFunction(timeseries>rampTime) = 1;
+            rampFunction(timeseries>=rampTime) = 1;
 
             obj.waveAmpTime = zeros(maxIt,2);
             obj.waveAmpTime(:,1) = timeseries;
@@ -693,7 +693,7 @@ classdef waveClass<handle
             % Used by postProcess for variable time step 
             maxIt = length(timeseries);
             rampFunction = (1+cos(pi+pi*timeseries/rampTime))/2;
-            rampFunction(timeseries>rampTime) = 1;
+            rampFunction(timeseries>=rampTime) = 1;
 
             obj.waveAmpTime = zeros(maxIt,2);
             obj.waveAmpTime(:,1) = timeseries;
@@ -732,12 +732,8 @@ classdef waveClass<handle
         function waveElevUser(obj,rampTime,maxIt,data,time)
             % Calculate imported wave elevation time history
             % used by: :meth:`waveClass.setup`.
-            if rampTime>0
-                rampFunction = (1+cos(pi+pi*time/rampTime))/2;
-                rampFunction(time>rampTime) = 1;
-            else
-                rampFunction = ones(1,length(time));
-            end
+            rampFunction = (1+cos(pi+pi*time/rampTime))/2;
+            rampFunction(time>=rampTime) = 1;
             
             obj.waveAmpTime = zeros(maxIt+1,2);
             data_t = data(:,1)';                    % Data Time [s]

--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -732,8 +732,12 @@ classdef waveClass<handle
         function waveElevUser(obj,rampTime,maxIt,data,time)
             % Calculate imported wave elevation time history
             % used by: :meth:`waveClass.setup`.
-            rampFunction = (1+cos(pi+pi*time/rampTime))/2;
-            rampFunction(time>rampTime) = 1;
+            if rampTime>0
+                rampFunction = (1+cos(pi+pi*time/rampTime))/2;
+                rampFunction(time>rampTime) = 1;
+            else
+                rampFunction = ones(1,length(time));
+            end
             
             obj.waveAmpTime = zeros(maxIt+1,2);
             data_t = data(:,1)';                    % Data Time [s]


### PR DESCRIPTION
This PR is a fix for issue #916. Because the equation for the rampFunction divides by the rampTime, it leads to an Nan value, which is not replaced by the interpolated elevation as it should be. The solution provided here checks if the rampTime is greater than 0 and applies a vector of 1s for the rampFunction if not.