### PR TITLE
Fixes saveViz feature for elevation import

### DIFF
--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -526,7 +526,7 @@ classdef responseClass<handle
                     nLeading = ceil(log10(max(t)));
                     tAnnot = sprintf(['time = %' num2str(nDecimals+nLeading+1) '.' num2str(nDecimals) 'f s'],t(i));
                     % Settings and labels
-                    caxis([min(-waves.amplitude) max(waves.amplitude)])
+                    caxis([min(waves.waveAmpTime(:,2)) max(waves.waveAmpTime(:,2))])
                     colormap winter
                     c = colorbar;
                     ylabel(c, 'Wave Elevation (m)')


### PR DESCRIPTION
The saveViz feature is throwing an error for elevation import because it cannot create the colorbar axis based on the wave amplitude. Since the wave amplitude is not defined for elevation import, I am changing the colorbar axis to just be based on the min and max of the wave elevation timeseries. This implementation should now work for all wave types.