### PR TITLE
Fix matlabdomain bug

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,5 +15,5 @@ dependencies:
   - sphinxcontrib-bibtex
   - pip:
     - https://github.com/Holzhaus/sphinx-multiversion/archive/refs/heads/master.zip
-    - git+https://github.com/H0R5E/matlabdomain.git@fix_params_bug#egg=sphinxcontrib-matlabdomain
+    - git+https://github.com/sphinx-contrib/matlabdomain.git#egg=sphinxcontrib-matlabdomain
     - sphinxext-remoteliteralinclude

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,5 +15,5 @@ dependencies:
   - sphinxcontrib-bibtex
   - pip:
     - https://github.com/Holzhaus/sphinx-multiversion/archive/refs/heads/master.zip
-    - https://github.com/H0R5E/matlabdomain/archive/refs/heads/fix_params_bug.zip
+    - git+https://github.com/H0R5E/matlabdomain.git@fix_params_bug#egg=matlabdomain
     - sphinxext-remoteliteralinclude

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,5 +15,5 @@ dependencies:
   - sphinxcontrib-bibtex
   - pip:
     - https://github.com/Holzhaus/sphinx-multiversion/archive/refs/heads/master.zip
-    - git+https://github.com/H0R5E/matlabdomain.git@fix_params_bug#egg=matlabdomain
+    - git+https://github.com/H0R5E/matlabdomain.git@fix_params_bug#egg=sphinxcontrib-matlabdomain
     - sphinxext-remoteliteralinclude

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,5 +15,5 @@ dependencies:
   - sphinxcontrib-bibtex
   - pip:
     - https://github.com/Holzhaus/sphinx-multiversion/archive/refs/heads/master.zip
-    - sphinxcontrib-matlabdomain
+    - https://github.com/H0R5E/matlabdomain/archive/refs/heads/fix_params_bug.zip
     - sphinxext-remoteliteralinclude

--- a/docs/user/code_structure.rst
+++ b/docs/user/code_structure.rst
@@ -495,7 +495,7 @@ any force or resistance to body motion outside of the reactive force required
 to prevent motion in a given DOF. At a high level, the constraint class 
 interacts with the rest of WEC-Sim as shown in the diagram below. Constraint 
 objects largely interact with other blocks through Simscape connections that 
-pass resistive forces to other bodies, constraints, ptos, etc. 
+pass resistive forces to other bodies, constraints, PTOs, etc. 
 
 .. figure:: /_static/images/code_structure/constraint_diagram.PNG
    :width: 750pt


### PR DESCRIPTION
This PR changes the target for [sphinxcontrib-matlabdomain](https://github.com/sphinx-contrib/matlabdomain) to [the upstream master](https://github.com/sphinx-contrib/matlabdomain) in the [`docs` workflow](https://github.com/WEC-Sim/WEC-Sim/blob/master/.github/workflows/docs.yml).

This is a temporary change until the updates are released.

Fixes #941 