### PR TITLE
Customizable DOFs for plotBEMIO

### DIFF
--- a/source/functions/BEMIO/formatPlot.m
+++ b/source/functions/BEMIO/formatPlot.m
@@ -46,6 +46,16 @@ sgtitle(titleString,'Interpreter','latex','FontWeight','bold','FontSize',12);
 legendStrings1D = legendStrings(:);
 legendStrings1D = legendStrings1D(~cellfun(@isempty, legendStrings1D));
 
+% Subplot formatting
+nPlots = length(subtitleStrings);
+if nPlots < 4
+    isp1 = 1;
+    isp2 = nPlots;
+else
+    isp1 = 2;
+    isp2 = ceil(nPlots/2);
+end
+
 % Figures
 nHydro = length(fieldnames(X));
 nBodiesTotal = 0;
@@ -56,50 +66,26 @@ for iHydro = 1:nHydro
     nBodiesTotal = nBodiesTotal + nBodies;
 
     % Surge
-    subplot('Position',[0.0731 0.3645 0.2521 0.4720])
-    hold('on');
-    box('on');
-    for iBody = 1:nBodies
-        plot(X.(tmp1),squeeze(Y.(tmp2)(1,iBody,:)),'LineWidth',1)  
-    end
-    if iHydro == nHydro
-        legend(legendStrings1D,'location','best','Box','off','Interpreter','none')
-        title(subtitleStrings(1));
-        xlabel(xString(1),'Interpreter','latex');
-        ylabel(yString(1),'Interpreter','latex');    
-    end
-    
-    % Heave
-    subplot('Position',[0.3983 0.3645 0.2521 0.4720]);
-    hold('on');
-    box('on');
-    for iBody = 1:nBodies
-        plot(X.(tmp1),squeeze(Y.(tmp2)(2,iBody,:)),'LineWidth',1);  
-    end
-    if iHydro == nHydro
-        legend(legendStrings1D,'location','best','Box','off','Interpreter','none')
-        title(subtitleStrings(2));
-        xlabel(xString(2),'Interpreter','latex');
-        ylabel(yString(2),'Interpreter','latex');
+%     subplot('Position',[0.0731 0.3645 0.2521 0.4720])
+    for isp = 1:nPlots
+        subplot(isp1,isp2,isp);
+        hold('on');
+        box('on');
+        for iBody = 1:nBodies
+            plot(X.(tmp1),squeeze(Y.(tmp2)(isp,iBody,:)),'LineWidth',1)  
+        end
+        if iHydro == nHydro
+            legend(legendStrings1D,'location','best','Box','off','Interpreter','none')
+            title(subtitleStrings(isp));
+            xlabel(xString(isp),'Interpreter','latex');
+            ylabel(yString(isp),'Interpreter','latex');    
+        end
     end
     
-    % pitch
-    subplot('Position',[0.7235 0.3645 0.2521 0.4720]);
-    hold('on');
-    box('on');
-    for iBody = 1:nBodies
-        plot(X.(tmp1),squeeze(Y.(tmp2)(3,iBody,:)),'LineWidth',1);  
-    end
-    if iHydro == nHydro
-        legend(legendStrings1D,'location','best','Box','off','Interpreter','none')
-        title(subtitleStrings(3));
-        xlabel(xString(3),'Interpreter','latex');
-        ylabel(yString(3),'Interpreter','latex');
-    end
 end
 
 % Footer
-annotation(fig,'textbox',[0.0 0.0 1.0 0.2628],...
+annotation(fig,'textbox',[0.0 0.0 1.0 0.075],...
     'String',notes,...
     'Interpreter','latex',...
     'FitBoxToText','off',...

--- a/source/functions/BEMIO/getDofNames.m
+++ b/source/functions/BEMIO/getDofNames.m
@@ -1,23 +1,23 @@
 function dofNames = getDofNames(dofList)
 
 dofNames = {}; % initialize empty cell.
-dofDefault = {'Surge','Sway','Heave','Roll','Pitch','Sway'}
+dofDefault = {'Surge','Sway','Heave','Roll','Pitch','Sway'};
 for k=1:length(dofList);
     if dofList(k,1) == dofList(k,2) && dofList(k,1) < 7 % loop default names
-        dofNames{k}= dofDefault{k};
+        dofNames{k}= dofDefault{dofList(k,1)};
     elseif dofList(k,1) == dofList(k,2) % gbm diagonals
         dofNames{k} = ['gbm' num2str(dofList(k,1)-6)];
     else
         if dofList(k,1) > 6
             dofPre = ['gbm' num2str(dofList(k,1)-6)];
         else
-            dofPre = dofDefault{k};
+            dofPre = dofDefault{dofList(k,1)};
         end
 
         if dofList(k,2) > 6
             dofSuff = ['gbm' num2str(dofList(k,2)-6)];
         else
-            dofSuff = dofDefault{k};
+            dofSuff = dofDefault{dofList(k,2)};
         end
         dofNames{k} = [dofPre '-' dofSuff];
     end

--- a/source/functions/BEMIO/getDofNames.m
+++ b/source/functions/BEMIO/getDofNames.m
@@ -1,0 +1,26 @@
+function dofNames = getDofNames(dofList)
+
+dofNames = {}; % initialize empty cell.
+dofDefault = {'Surge','Sway','Heave','Roll','Pitch','Sway'}
+for k=1:length(dofList);
+    if dofList(k,1) == dofList(k,2) && dofList(k,1) < 7 % loop default names
+        dofNames{k}= dofDefault{k};
+    elseif dofList(k,1) == dofList(k,2) % gbm diagonals
+        dofNames{k} = ['gbm' num2str(dofList(k,1)-6)];
+    else
+        if dofList(k,1) > 6
+            dofPre = ['gbm' num2str(dofList(k,1)-6)];
+        else
+            dofPre = dofDefault{k};
+        end
+
+        if dofList(k,2) > 6
+            dofSuff = ['gbm' num2str(dofList(k,2)-6)];
+        else
+            dofSuff = dofDefault{k};
+        end
+        dofNames{k} = [dofPre '-' dofSuff];
+    end
+end
+
+end

--- a/source/functions/BEMIO/plotAddedMass.m
+++ b/source/functions/BEMIO/plotAddedMass.m
@@ -24,11 +24,11 @@ subtitleStrings = getDofNames(dofList);
 
 figHandle = figure('Position',[50,500,975,521]);
 titleString = ['Normalized Added Mass: $$\bar{A}_{i,j}(\omega) = {\frac{A_{i,j}(\omega)}{\rho}}$$'];
-id = 0
+id = 0;
 for rIdx = 1:length(dofList(:,1))
-        id = id+1;
-        xString{id} = '$$\omega (rad/s)$$';
-        yString{id} = ['$$\bar{A}_{',num2str(dofList(rIdx,1)),',',num2str(dofList(rIdx,2)),'}(\omega)$$'];
+    id = id+1;
+    xString{id} = '$$\omega (rad/s)$$';
+    yString{id} = ['$$\bar{A}_{',num2str(dofList(rIdx,1)),',',num2str(dofList(rIdx,2)),'}(\omega)$$'];
 end
 
 notes = {'Notes:',...
@@ -44,15 +44,17 @@ for ii = 1:numHydro
     numBod = varargin{ii}.Nb;
     tmp1 = strcat('X',num2str(ii));
     X.(tmp1) = varargin{ii}.w;
-    tmp2 = strcat('Y',num2str(ii));        
+    tmp2 = strcat('Y',num2str(ii));
+    a = 0;
     for i = 1:numBod    
         m = varargin{ii}.dof(i);
         id = 0;
         for rIdx = 1:length(dofList(:,1))
-                id = id + 1;
-                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.A(dofList(rIdx,1),dofList(rIdx,2),:));
+            id = id + 1;
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.A(a+dofList(rIdx,1),a+dofList(rIdx,2),:));
         end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
+        a = a + m;
     end
 end
 

--- a/source/functions/BEMIO/plotAddedMass.m
+++ b/source/functions/BEMIO/plotAddedMass.m
@@ -1,12 +1,16 @@
-function plotAddedMass(varargin)
+function plotAddedMass(dofList, varargin)
 % Plots the added mass for each hydro structure's bodies in
-% the heave, surge and pitch degrees of freedom.
+% the given degrees of freedom.
 % 
 % Usage:
-% ``plotAddedMass(hydro, hydro2, hydro3, ...)``
+% ``plotAddedMass([1], hydro, hydro2, hydro3, ...)``
+% ``plotAddedMass([1 3 5], hydro, hydro2, hydro3, ...)``
 % 
 % Parameters
 % ----------
+%     dofList : [1 n] int vector
+%         Array of DOFs that will be plotted. Default = [1 3 5]
+% 
 %     varargin : struct(s)
 %         The hydroData structure(s) created by the other BEMIO functions.
 %         One or more may be input.
@@ -16,11 +20,16 @@ if isempty(varargin)
         'structures when calling: plotAddedMass(hydro1, hydro2, ...)']);
 end
 
+dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
+    'dof7','dof8','dof9','dof10','dof11','dof12'};
+
 figHandle = figure('Position',[50,500,975,521]);
 titleString = ['Normalized Added Mass: $$\bar{A}_{i,j}(\omega) = {\frac{A_{i,j}(\omega)}{\rho}}$$'];
-subtitleStrings = {'Surge','Heave','Pitch'};
-xString = {'$$\omega (rad/s)$$','$$\omega (rad/s)$$','$$\omega (rad/s)$$'};
-yString = {'$$\bar{A}_{1,1}(\omega)$$','$$\bar{A}_{3,3}(\omega)$$','$$\bar{A}_{5,5}(\omega)$$'};
+subtitleStrings = dofNames(dofList);
+for dof = dofList
+    xString{dof} = '$$\omega (rad/s)$$';
+    yString{dof} = ['$$\bar{A}_{',num2str(dof),',',num2str(dof),'}(\omega)$$'];
+end
 
 notes = {'Notes:',...
     ['$$\bullet$$ $$\bar{A}_{i,j}(\omega)$$ should tend towards a constant, ',...
@@ -39,9 +48,11 @@ for ii = 1:numHydro
     a = 0;            
     for i = 1:numBod    
         m = varargin{ii}.dof(i);
-        Y.(tmp2)(1,i,:) = squeeze(varargin{ii}.A(a+1,a+1,:));
-        Y.(tmp2)(2,i,:) = squeeze(varargin{ii}.A(a+3,a+3,:));
-        Y.(tmp2)(3,i,:) = squeeze(varargin{ii}.A(a+5,a+5,:));
+        id = 0;
+        for d = dofList
+            id = id + 1;
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.A(a+d,a+d,:));
+        end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
         a = a + m;
     end

--- a/source/functions/BEMIO/plotAddedMass.m
+++ b/source/functions/BEMIO/plotAddedMass.m
@@ -20,15 +20,15 @@ if isempty(varargin)
         'structures when calling: plotAddedMass(hydro1, hydro2, ...)']);
 end
 
-dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
-    'dof7','dof8','dof9','dof10','dof11','dof12'};
+subtitleStrings = getDofNames(dofList);
 
 figHandle = figure('Position',[50,500,975,521]);
 titleString = ['Normalized Added Mass: $$\bar{A}_{i,j}(\omega) = {\frac{A_{i,j}(\omega)}{\rho}}$$'];
-subtitleStrings = dofNames(dofList);
-for dof = dofList
-    xString{dof} = '$$\omega (rad/s)$$';
-    yString{dof} = ['$$\bar{A}_{',num2str(dof),',',num2str(dof),'}(\omega)$$'];
+id = 0
+for rIdx = 1:length(dofList(:,1))
+        id = id+1;
+        xString{id} = '$$\omega (rad/s)$$';
+        yString{id} = ['$$\bar{A}_{',num2str(dofList(rIdx,1)),',',num2str(dofList(rIdx,2)),'}(\omega)$$'];
 end
 
 notes = {'Notes:',...
@@ -44,17 +44,15 @@ for ii = 1:numHydro
     numBod = varargin{ii}.Nb;
     tmp1 = strcat('X',num2str(ii));
     X.(tmp1) = varargin{ii}.w;
-    tmp2 = strcat('Y',num2str(ii));
-    a = 0;            
+    tmp2 = strcat('Y',num2str(ii));        
     for i = 1:numBod    
         m = varargin{ii}.dof(i);
         id = 0;
-        for d = dofList
-            id = id + 1;
-            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.A(a+d,a+d,:));
+        for rIdx = 1:length(dofList(:,1))
+                id = id + 1;
+                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.A(dofList(rIdx,1),dofList(rIdx,2),:));
         end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
-        a = a + m;
     end
 end
 

--- a/source/functions/BEMIO/plotBEMIO.m
+++ b/source/functions/BEMIO/plotBEMIO.m
@@ -1,15 +1,19 @@
-function plotBEMIO(varargin)
+function plotBEMIO(dofList,varargin)
 % Plots the added mass, radiation damping, radiation IRF, excitation force
 % magnitude, excitation force phase, and excitation IRF for each body in
-% the heave, surge and pitch degrees of freedom.
+% the given degrees of freedom.
 % 
 % Usage: 
 % ``plotBEMIO(hydro, hydro2, hydro3, ...)``
+% ``plotBEMIO([1 3 5], hydro, hydro2, hydro3, ...)``
 % 
 % See ``WEC-Sim\examples\BEMIO`` for additional examples.
 % 
 % Parameters
 % ----------
+%     dofList : [1 n] int vector (optional)
+%         Array of DOFs that will be plotted. Default = [1 3 5]
+%     
 %     varargin : struct(s)
 %         The hydroData structure(s) created by the other BEMIO functions.
 %         One or more may be input.
@@ -26,27 +30,40 @@ function plotBEMIO(varargin)
 %     If varargin is empty, varargin{:} gives passes nothing to the
 %     plotting functions.
 
+%% Set-up and error checking parameters
+% If dofList is not input by the users, it will be read as the first hydro
+% struct. In this case, add if to varargin to lump all the hydro structs
+% together. Defaults to [1 3 5].
+if isstruct(dofList)
+    varargin = {dofList varargin{:}};
+    dofList = [1 3 5];
+end
+
+if isempty(dofList)
+    dofList = [1 3 5];
+end
+
 if isempty(varargin)
-    error(['plotBEMIO: No arguments passed. Include one or more hydro ' ...
+    error(['No hydro data passed. Include one or more hydro ' ...
         'structures when calling: plotBEMIO(hydro1, hydro2, ...)']);
 end
 
 %% Added Mass
-plotAddedMass(varargin{:})
+plotAddedMass(dofList,varargin{:})
 
 %% Radiation Damping
-plotRadiationDamping(varargin{:})
+plotRadiationDamping(dofList,varargin{:})
 % 
 %% Radiation IRFs
-plotRadiationIRF(varargin{:})
+plotRadiationIRF(dofList,varargin{:})
 
 %% Excitation Force Magnitude
-plotExcitationMagnitude(varargin{:})
+plotExcitationMagnitude(dofList,varargin{:})
 
 %% Excitation Force Phase
-plotExcitationPhase(varargin{:})
+plotExcitationPhase(dofList,varargin{:})
 
 %% Excitation IRFs
-plotExcitationIRF(varargin{:})
+plotExcitationIRF(dofList,varargin{:})
 
 end

--- a/source/functions/BEMIO/plotBEMIO.m
+++ b/source/functions/BEMIO/plotBEMIO.m
@@ -33,20 +33,41 @@ function plotBEMIO(dofList,varargin)
 %% Set-up and error checking parameters
 % If dofList is not input by the users, it will be read as the first hydro
 % struct. In this case, add if to varargin to lump all the hydro structs
-% together. Defaults to [1 3 5].
+% together. Defaults to [1,1; 3,3; 5,5].
 if isstruct(dofList)
     varargin = {dofList varargin{:}};
-    dofList = [1 3 5];
+    dofList = [1,1; 3,3; 5,5];
 end
 
 if isempty(dofList)
-    dofList = [1 3 5];
+    dofList = [1,1; 3,3; 5,5];
+end
+
+if min(size(dofList))==1
+    warning('dofList is 1xN or Nx1. Assuming matrix diagonal indices \n')
+    [~,dim]=min(size(dofList));
+    if dim == 1
+        dofList = (repmat(dofList,2,1)).';
+    elseif dim ==2
+        dofList = repmat(dofList,1,2);
+    end
+end
+
+[nRow,nCol]=size(dofList);
+if nRow ==2 && nCol ~=2 % force column vector;
+    dofList = dofList.'
+elseif nRow == 2 && nCol ==2;
+    warning('dofList is 2x2. Interpreting as [dof1Row,dof1Col; dof2Row,dof2Col] \n')
 end
 
 if isempty(varargin)
     error(['No hydro data passed. Include one or more hydro ' ...
-        'structures when calling: plotBEMIO(hydro1, hydro2, ...)']);
+        'structures when calling: plotBEMIO(hydro1, hydro2, ...) \n']);
 end
+
+% For excitation coefficients, only "diagonal" dofs exist
+idx = find(dofList(:,1) == dofList(:,2));
+diagDof = dofList(idx,:);
 
 %% Added Mass
 plotAddedMass(dofList,varargin{:})
@@ -58,12 +79,12 @@ plotRadiationDamping(dofList,varargin{:})
 plotRadiationIRF(dofList,varargin{:})
 
 %% Excitation Force Magnitude
-plotExcitationMagnitude(dofList,varargin{:})
+plotExcitationMagnitude(diagDof,varargin{:})
 
 %% Excitation Force Phase
-plotExcitationPhase(dofList,varargin{:})
+plotExcitationPhase(diagDof,varargin{:})
 
 %% Excitation IRFs
-plotExcitationIRF(dofList,varargin{:})
+plotExcitationIRF(diagDof,varargin{:})
 
 end

--- a/source/functions/BEMIO/plotExcitationIRF.m
+++ b/source/functions/BEMIO/plotExcitationIRF.m
@@ -1,12 +1,16 @@
-function plotExcitationIRF(varargin)
+function plotExcitationIRF(dofList, varargin)
 % Plots the excitation IRF for each hydro structure's bodies in
-% the heave, surge and pitch degrees of freedom.
+% the given degrees of freedom.
 % 
 % Usage:
-% ``plotExcitationIRF(hydro, hydro2, hydro3, ...)``
+% ``plotExcitationIRF([1], hydro, hydro2, hydro3, ...)``
+% ``plotExcitationIRF([1 3 5], hydro, hydro2, hydro3, ...)``
 % 
 % Parameters
 % ----------
+%     dofList : [1 n] int vector
+%         Array of DOFs that will be plotted. Default = [1 3 5]
+%     
 %     varargin : struct(s)
 %         The hydroData structure(s) created by the other BEMIO functions.
 %         One or more may be input.
@@ -17,15 +21,19 @@ if isempty(varargin)
         'structures when calling: plotExcitationIRF(hydro1, hydro2, ...)']);
 end
 
+dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
+    'dof7','dof8','dof9','dof10','dof11','dof12'};
+
 B=1;  % Wave heading index
 figHandle = figure('Position',[950,100,975,521]);
 titleString = ['Normalized Excitation Impulse Response Functions:   ',...
     '$$\bar{K}_i(t) = {\frac{1}{2\pi}}\int_{-\infty}^{\infty}{\frac{X_i(\omega,\theta)e^{i{\omega}t}}{{\rho}g}}d\omega$$'];
-subtitleStrings = {'Surge','Heave','Pitch'};
-xString = {'$$t (s)$$','$$t (s)$$','$$t (s)$$'};
-yString = {['$$\bar{K}_1(t,\theta$$',' = ',num2str(varargin{1}.theta(B)),'$$^{\circ}$$)'],...
-    ['$$\bar{K}_3(t,\theta$$',' = ',num2str(varargin{1}.theta(B)),'$$^{\circ}$$)'],...
-    ['$$\bar{K}_5(t,\theta$$',' = ',num2str(varargin{1}.theta(B)),'$$^{\circ}$$)']};
+subtitleStrings = dofNames(dofList);
+for dof = dofList
+    xString{dof} = '$$t (s)$$';
+    yString{dof} = ['$$\bar{K}_',num2str(dof),'(t,\theta$$',' = ',...
+        num2str(varargin{1}.theta(B)),'$$^{\circ}$$)'];
+end
 
 notes = {'Notes:',...
     ['$$\bullet$$ The IRF should tend towards zero within the specified timeframe. ',...
@@ -44,9 +52,11 @@ for ii = 1:numHydro
     a = 0;
     for i = 1:numBod
         m = varargin{ii}.dof(i);
-        Y.(tmp2)(1,i,:) = squeeze(varargin{ii}.ex_K(a+1,B,:));
-        Y.(tmp2)(2,i,:) = squeeze(varargin{ii}.ex_K(a+3,B,:));
-        Y.(tmp2)(3,i,:) = squeeze(varargin{ii}.ex_K(a+5,B,:));
+        id = 0;
+        for d = dofList
+            id = id + 1;
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ex_K(a+d,B,:));
+        end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
         a = a + m;
     end

--- a/source/functions/BEMIO/plotExcitationIRF.m
+++ b/source/functions/BEMIO/plotExcitationIRF.m
@@ -21,17 +21,16 @@ if isempty(varargin)
         'structures when calling: plotExcitationIRF(hydro1, hydro2, ...)']);
 end
 
-dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
-    'dof7','dof8','dof9','dof10','dof11','dof12'};
+subtitleStrings = getDofNames(dofList);
 
 B=1;  % Wave heading index
 figHandle = figure('Position',[950,100,975,521]);
 titleString = ['Normalized Excitation Impulse Response Functions:   ',...
     '$$\bar{K}_i(t) = {\frac{1}{2\pi}}\int_{-\infty}^{\infty}{\frac{X_i(\omega,\theta)e^{i{\omega}t}}{{\rho}g}}d\omega$$'];
-subtitleStrings = dofNames(dofList);
-for dof = dofList
+
+for dof = 1:length(dofList)
     xString{dof} = '$$t (s)$$';
-    yString{dof} = ['$$\bar{K}_',num2str(dof),'(t,\theta$$',' = ',...
+    yString{dof} = ['$$\bar{K}_',num2str(dofList(dof)),'(t,\theta$$',' = ',...
         num2str(varargin{1}.theta(B)),'$$^{\circ}$$)'];
 end
 
@@ -53,9 +52,9 @@ for ii = 1:numHydro
     for i = 1:numBod
         m = varargin{ii}.dof(i);
         id = 0;
-        for d = dofList
+        for d = 1:length(dofList)
             id = id + 1;
-            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ex_K(a+d,B,:));
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ex_K(a+dofList(d),B,:));
         end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
         a = a + m;

--- a/source/functions/BEMIO/plotExcitationMagnitude.m
+++ b/source/functions/BEMIO/plotExcitationMagnitude.m
@@ -1,12 +1,16 @@
-function plotExcitationMagnitude(varargin)
+function plotExcitationMagnitude(dofList, varargin)
 % Plots the excitation force magnitude for each hydro structure's bodies in
-% the heave, surge and pitch degrees of freedom.
+% the given degrees of freedom.
 % 
 % Usage:
-% ``plotExcitationMagnitude(hydro, hydro2, hydro3, ...)``
+% ``plotExcitationMagnitude([1], hydro, hydro2, hydro3, ...)``
+% ``plotExcitationMagnitude([1 3 5], hydro, hydro2, hydro3, ...)``
 % 
 % Parameters
 % ----------
+%     dofList : [1 n] int vector
+%         Array of DOFs that will be plotted. Default = [1 3 5]
+%     
 %     varargin : struct(s)
 %         The hydroData structure(s) created by the other BEMIO functions.
 %         One or more may be input.
@@ -17,15 +21,19 @@ if isempty(varargin)
         'structures when calling: plotExcitationMagnitude(hydro1, hydro2, ...)']);
 end
 
+dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
+    'dof7','dof8','dof9','dof10','dof11','dof12'};
+
 B=1;  % Wave heading index
 figHandle = figure('Position',[950,500,975,521]);
 titleString = ['Normalized Excitation Force Magnitude: ',...
     '$$\bar{X_i}(\omega,\theta) = {\frac{X_i(\omega,\theta)}{{\rho}g}}$$'];
-subtitleString = {'Surge','Heave','Pitch'};
-xString = {'$$\omega (rad/s)$$','$$\omega (rad/s)$$','$$\omega (rad/s)$$'};
-yString = {['$$\bar{X_1}(\omega,\theta$$',' = ',num2str(varargin{1}.theta(B)),'$$^{\circ}$$)'],...
-    ['$$\bar{X_3}(\omega,\theta$$',' = ',num2str(varargin{1}.theta(B)),'$$^{\circ}$$)'],...
-    ['$$\bar{X_5}(\omega,\theta$$',' = ',num2str(varargin{1}.theta(B)),'$$^{\circ}$$)']};
+subtitleStrings = dofNames(dofList);
+for dof = dofList
+    xString{dof} = '$$\omega (rad/s)$$';
+    yString{dof} = ['$$\bar{X_',num2str(dof),'}(\omega,\theta$$',' = ',...
+        num2str(varargin{1}.theta(B)),'$$^{\circ}$$)'];
+end
 
 notes = {''};
 
@@ -38,15 +46,17 @@ for ii = 1:numHydro
     a = 0;
     for i = 1:numBod
         m = varargin{ii}.dof(i);
-        Y.(tmp2)(1,i,:) = squeeze(varargin{ii}.ex_ma(a+1,B,:));
-        Y.(tmp2)(2,i,:) = squeeze(varargin{ii}.ex_ma(a+3,B,:));
-        Y.(tmp2)(3,i,:) = squeeze(varargin{ii}.ex_ma(a+5,B,:));
+        id = 0;
+        for d = dofList
+            id = id + 1;
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ex_ma(a+d,B,:));
+        end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
         a = a + m;
     end
 end
 
-formatPlot(figHandle,titleString,subtitleString,xString,yString,X,Y,legendStrings,notes);
+formatPlot(figHandle,titleString,subtitleStrings,xString,yString,X,Y,legendStrings,notes);
 saveas(figHandle,'Excitation_Magnitude.png');
 
 end

--- a/source/functions/BEMIO/plotExcitationMagnitude.m
+++ b/source/functions/BEMIO/plotExcitationMagnitude.m
@@ -21,17 +21,16 @@ if isempty(varargin)
         'structures when calling: plotExcitationMagnitude(hydro1, hydro2, ...)']);
 end
 
-dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
-    'dof7','dof8','dof9','dof10','dof11','dof12'};
+subtitleStrings = getDofNames(dofList);
 
 B=1;  % Wave heading index
 figHandle = figure('Position',[950,500,975,521]);
 titleString = ['Normalized Excitation Force Magnitude: ',...
     '$$\bar{X_i}(\omega,\theta) = {\frac{X_i(\omega,\theta)}{{\rho}g}}$$'];
-subtitleStrings = dofNames(dofList);
-for dof = dofList
+
+for dof = 1:length(dofList)
     xString{dof} = '$$\omega (rad/s)$$';
-    yString{dof} = ['$$\bar{X_',num2str(dof),'}(\omega,\theta$$',' = ',...
+    yString{dof} = ['$$\bar{X_',num2str(dofList(dof)),'}(\omega,\theta$$',' = ',...
         num2str(varargin{1}.theta(B)),'$$^{\circ}$$)'];
 end
 
@@ -47,9 +46,9 @@ for ii = 1:numHydro
     for i = 1:numBod
         m = varargin{ii}.dof(i);
         id = 0;
-        for d = dofList
+        for d = 1:length(dofList)
             id = id + 1;
-            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ex_ma(a+d,B,:));
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ex_ma(a+dofList(d),B,:));
         end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
         a = a + m;

--- a/source/functions/BEMIO/plotExcitationPhase.m
+++ b/source/functions/BEMIO/plotExcitationPhase.m
@@ -1,12 +1,16 @@
-function plotExcitationPhase(varargin)
+function plotExcitationPhase(dofList, varargin)
 % Plots the excitation force phase for each hydro structure's bodies in
-% the heave, surge and pitch degrees of freedom.
+% the given degrees of freedom.
 % 
 % Usage:
-% ``plotExcitationPhase(hydro, hydro2, hydro3, ...)``
+% ``plotExcitationPhase([1], hydro, hydro2, hydro3, ...)``
+% ``plotExcitationPhase([1 3 5], hydro, hydro2, hydro3, ...)``
 % 
 % Parameters
 % ----------
+%     dofList : [1 n] int vector
+%         Array of DOFs that will be plotted. Default = [1 3 5]
+%     
 %     varargin : struct(s)
 %         The hydroData structure(s) created by the other BEMIO functions.
 %         One or more may be input.
@@ -17,14 +21,18 @@ if isempty(varargin)
         'structures when calling: plotExcitationPhase(hydro1, hydro2, ...)']);
 end
 
+dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
+    'dof7','dof8','dof9','dof10','dof11','dof12'};
+
 B=1;  % Wave heading index
 figHandle = figure('Position',[950,300,975,521]);
 titleString = ['Excitation Force Phase: $$\phi_i(\omega,\theta)$$'];
-subtitleString = {'Surge','Heave','Pitch'};
-xString = {'$$\omega (rad/s)$$','$$\omega (rad/s)$$','$$\omega (rad/s)$$'};
-yString = {['$$\phi_1(\omega,\theta$$',' = ',num2str(varargin{1}.theta(B)),'$$^{\circ})$$'],...
-    ['$$\phi_3(\omega,\theta$$',' = ',num2str(varargin{1}.theta(B)),'$$^{\circ}$$)'],...
-    ['$$\phi_5(\omega,\theta$$',' = ',num2str(varargin{1}.theta(B)),'$$^{\circ}$$)']};
+subtitleStrings = dofNames(dofList);
+for dof = dofList
+    xString{dof} = '$$\omega (rad/s)$$';
+    yString{dof} = ['$$\phi_',num2str(dof),'(\omega,\theta$$',' = ',...
+        num2str(varargin{1}.theta(B)),'$$^{\circ})$$'];
+end
 
 notes = {''};
 
@@ -37,15 +45,17 @@ for ii = 1:numHydro
     a = 0;
     for i = 1:numBod
         m = varargin{ii}.dof(i);
-        Y.(tmp2)(1,i,:) = squeeze(varargin{ii}.ex_ph(a+1,B,:));
-        Y.(tmp2)(2,i,:) = squeeze(varargin{ii}.ex_ph(a+3,B,:));
-        Y.(tmp2)(3,i,:) = squeeze(varargin{ii}.ex_ph(a+5,B,:));
+        id = 0;
+        for d = dofList
+            id = id + 1;
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ex_ph(a+d,B,:));
+        end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
         a = a + m;
     end
 end
 
-formatPlot(figHandle,titleString,subtitleString,xString,yString,X,Y,legendStrings,notes)  
+formatPlot(figHandle,titleString,subtitleStrings,xString,yString,X,Y,legendStrings,notes)  
 saveas(figHandle,'Excitation_Phase.png');
 
 end

--- a/source/functions/BEMIO/plotExcitationPhase.m
+++ b/source/functions/BEMIO/plotExcitationPhase.m
@@ -21,16 +21,15 @@ if isempty(varargin)
         'structures when calling: plotExcitationPhase(hydro1, hydro2, ...)']);
 end
 
-dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
-    'dof7','dof8','dof9','dof10','dof11','dof12'};
+subtitleStrings = getDofNames(dofList);
 
 B=1;  % Wave heading index
 figHandle = figure('Position',[950,300,975,521]);
 titleString = ['Excitation Force Phase: $$\phi_i(\omega,\theta)$$'];
-subtitleStrings = dofNames(dofList);
-for dof = dofList
+
+for dof = 1:length(dofList)
     xString{dof} = '$$\omega (rad/s)$$';
-    yString{dof} = ['$$\phi_',num2str(dof),'(\omega,\theta$$',' = ',...
+    yString{dof} = ['$$\phi_',num2str(dofList(dof)),'(\omega,\theta$$',' = ',...
         num2str(varargin{1}.theta(B)),'$$^{\circ})$$'];
 end
 
@@ -46,9 +45,9 @@ for ii = 1:numHydro
     for i = 1:numBod
         m = varargin{ii}.dof(i);
         id = 0;
-        for d = dofList
+        for d = 1:length(dofList)
             id = id + 1;
-            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ex_ph(a+d,B,:));
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ex_ph(a+dofList(d),B,:));
         end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
         a = a + m;

--- a/source/functions/BEMIO/plotRadiationDamping.m
+++ b/source/functions/BEMIO/plotRadiationDamping.m
@@ -1,12 +1,16 @@
-function plotRadiationDamping(varargin)
+function plotRadiationDamping(dofList, varargin)
 % Plots the radiation damping for each hydro structure's bodies in
-% the heave, surge and pitch degrees of freedom.
+% the given degrees of freedom.
 % 
 % Usage:
-% ``plotRadiationDamping(hydro, hydro2, hydro3, ...)``
+% ``plotRadiationDamping([1], hydro, hydro2, hydro3, ...)``
+% ``plotRadiationDamping([1 3 5], hydro, hydro2, hydro3, ...)``
 % 
 % Parameters
 % ----------
+%     dofList : [1 n] int vector
+%         Array of DOFs that will be plotted. Default = [1 3 5]
+% 
 %     varargin : struct(s)
 %         The hydroData structure(s) created by the other BEMIO functions.
 %         One or more may be input.
@@ -17,11 +21,16 @@ if isempty(varargin)
         'structures when calling: plotRadiationDamping(hydro1, hydro2, ...)']);
 end
 
+dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
+    'dof7','dof8','dof9','dof10','dof11','dof12'};
+
 figHandle = figure('Position',[50,300,975,521]);
 titleString = ['Normalized Radiation Damping: $$\bar{B}_{i,j}(\omega) = {\frac{B_{i,j}(\omega)}{\rho\omega}}$$'];
-subtitleStrings = {'Surge','Heave','Pitch'};
-xString = {'$$\omega (rad/s)$$','$$\omega (rad/s)$$','$$\omega (rad/s)$$'};
-yString = {'$$\bar{B}_{1,1}(\omega)$$','$$\bar{B}_{3,3}(\omega)$$','$$\bar{B}_{5,5}(\omega)$$'};
+subtitleStrings = dofNames(dofList);
+for dof = dofList
+    xString{dof} = '$$\omega (rad/s)$$';
+    yString{dof} = ['$$\bar{B}_{',num2str(dof),',',num2str(dof),'}(\omega)$$'];
+end
 
 notes = {'Notes:',...
     ['$$\bullet$$ $$\bar{B}_{i,j}(\omega)$$ should tend towards zero within ',...
@@ -40,9 +49,11 @@ for ii=1:numHydro
     a = 0;            
     for i = 1:numBod
         m = varargin{ii}.dof(i);
-        Y.(tmp2)(1,i,:) = squeeze(varargin{ii}.B(a+1,a+1,:));
-        Y.(tmp2)(2,i,:) = squeeze(varargin{ii}.B(a+3,a+3,:));
-        Y.(tmp2)(3,i,:) = squeeze(varargin{ii}.B(a+5,a+5,:));
+        id = 0;
+        for d = dofList
+            id = id + 1;
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.B(a+d,a+d,:));
+        end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
         a = a + m;
     end

--- a/source/functions/BEMIO/plotRadiationDamping.m
+++ b/source/functions/BEMIO/plotRadiationDamping.m
@@ -51,10 +51,11 @@ for ii=1:numHydro
         m = varargin{ii}.dof(i);
         id = 0;
         for rIdx = 1:length(dofList(:,1))
-                id = id + 1;
-                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.B(dofList(rIdx,1),dofList(rIdx,2),:));
+            id = id + 1;
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.B(a+dofList(rIdx,1),a+dofList(rIdx,2),:));
         end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
+        a = a + m;
     end
 end
 

--- a/source/functions/BEMIO/plotRadiationDamping.m
+++ b/source/functions/BEMIO/plotRadiationDamping.m
@@ -21,15 +21,15 @@ if isempty(varargin)
         'structures when calling: plotRadiationDamping(hydro1, hydro2, ...)']);
 end
 
-dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
-    'dof7','dof8','dof9','dof10','dof11','dof12'};
+subtitleStrings = getDofNames(dofList);
 
 figHandle = figure('Position',[50,300,975,521]);
 titleString = ['Normalized Radiation Damping: $$\bar{B}_{i,j}(\omega) = {\frac{B_{i,j}(\omega)}{\rho\omega}}$$'];
-subtitleStrings = dofNames(dofList);
-for dof = dofList
-    xString{dof} = '$$\omega (rad/s)$$';
-    yString{dof} = ['$$\bar{B}_{',num2str(dof),',',num2str(dof),'}(\omega)$$'];
+id = 0
+for rIdx = 1:length(dofList(:,1))
+   id = id+1;
+   xString{id} = '$$\omega (rad/s)$$';
+   yString{id} = ['$$\bar{B}_{',num2str(dofList(rIdx,1)),',',num2str(dofList(rIdx,2)),'}(\omega)$$'];
 end
 
 notes = {'Notes:',...
@@ -47,15 +47,14 @@ for ii=1:numHydro
     X.(tmp1) = varargin{ii}.w;
     tmp2 = strcat('Y',num2str(ii));
     a = 0;            
-    for i = 1:numBod
+    for i = 1:numBod    
         m = varargin{ii}.dof(i);
         id = 0;
-        for d = dofList
-            id = id + 1;
-            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.B(a+d,a+d,:));
+        for rIdx = 1:length(dofList(:,1))
+                id = id + 1;
+                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.B(dofList(rIdx,1),dofList(rIdx,2),:));
         end
         legendStrings{i,ii} = [varargin{ii}.body{i}];
-        a = a + m;
     end
 end
 

--- a/source/functions/BEMIO/plotRadiationIRF.m
+++ b/source/functions/BEMIO/plotRadiationIRF.m
@@ -21,16 +21,17 @@ if isempty(varargin)
         'structures when calling: plotRadiationIRF(hydro1, hydro2, ...)']);
 end
 
-dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
-    'dof7','dof8','dof9','dof10','dof11','dof12'};
+subtitleStrings =  getDofNames(dofList);
 
 figHandle = figure('Position',[50,100,975,521]);
 titleString = ['Normalized Radiation Impulse Response Functions: ',...
     '$$\bar{K}_{i,j}(t) = {\frac{2}{\pi}}\int_0^{\infty}{\frac{B_{i,j}(\omega)}{\rho}}\cos({\omega}t)d\omega$$'];
-subtitleStrings = dofNames(dofList);
-for dof = dofList
-    xString{dof} = '$$t (s)$$';
-    yString{dof} = ['$$\bar{K}_{',num2str(dof),',',num2str(dof),'}(t)$$'];
+
+id = 0
+for rIdx = 1:length(dofList(:,1))
+        id = id+1;
+        xString{id} = '$$\omega (rad/s)$$';
+        yString{id} = ['$$\bar{K}_{',num2str(dofList(rIdx,1)),',',num2str(dofList(rIdx,2)),'}(t)$$'];
 end
 
 notes = {'Notes:',...
@@ -40,7 +41,7 @@ notes = {'Notes:',...
     ['$$\bullet$$ Only the IRFs for the surge, heave, and pitch DOFs are plotted ',...
     'here. If another DOF is significant to the system, that IRF should also ',...
     'be plotted and verified before proceeding.']};
-    
+    %ra_K
 numHydro = length(varargin);
 for ii = 1:numHydro
     numBod = varargin{ii}.Nb;
@@ -52,18 +53,18 @@ for ii = 1:numHydro
     for iBod = 1:numBod
         m = varargin{ii}.dof(iBod);
         id = 0;
-        for d = dofList
-            id = id + 1;
-            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ra_K(a+d,a+d,:));
+        for rIdx = 1:length(dofList(:,1))
+                id = id + 1;
+                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ra_K(dofList(rIdx,1),dofList(rIdx,1),:));
         end
         legendStrings{i,ii} = [varargin{ii}.body{iBod}];
         i = i+1;
         if isfield(varargin{ii},'ss_A')==1
-            id = 0;
-            for d = dofList
+           id = 0;
+        for rIdx = 1:length(dofList(:,1))
                 id = id + 1;
-                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ss_K(a+d,a+d,:));
-            end
+                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ss_K(dofList(rIdx,1),dofList(rIdx,2),:));
+        end
             legendStrings{i,ii} = [varargin{ii}.body{iBod},' (SS)'];
             i = i+1;
         end

--- a/source/functions/BEMIO/plotRadiationIRF.m
+++ b/source/functions/BEMIO/plotRadiationIRF.m
@@ -30,7 +30,7 @@ titleString = ['Normalized Radiation Impulse Response Functions: ',...
 id = 0
 for rIdx = 1:length(dofList(:,1))
         id = id+1;
-        xString{id} = '$$\omega (rad/s)$$';
+        xString{id} = '$$t (s)$$';
         yString{id} = ['$$\bar{K}_{',num2str(dofList(rIdx,1)),',',num2str(dofList(rIdx,2)),'}(t)$$'];
 end
 

--- a/source/functions/BEMIO/plotRadiationIRF.m
+++ b/source/functions/BEMIO/plotRadiationIRF.m
@@ -54,17 +54,17 @@ for ii = 1:numHydro
         m = varargin{ii}.dof(iBod);
         id = 0;
         for rIdx = 1:length(dofList(:,1))
-                id = id + 1;
-                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ra_K(dofList(rIdx,1),dofList(rIdx,1),:));
+            id = id + 1;
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ra_K(a+dofList(rIdx,1),a+dofList(rIdx,1),:));
         end
         legendStrings{i,ii} = [varargin{ii}.body{iBod}];
         i = i+1;
         if isfield(varargin{ii},'ss_A')==1
-           id = 0;
-        for rIdx = 1:length(dofList(:,1))
+            id = 0;
+            for rIdx = 1:length(dofList(:,1))
                 id = id + 1;
-                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ss_K(dofList(rIdx,1),dofList(rIdx,2),:));
-        end
+                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ss_K(a+dofList(rIdx,1),a+dofList(rIdx,2),:));
+            end
             legendStrings{i,ii} = [varargin{ii}.body{iBod},' (SS)'];
             i = i+1;
         end

--- a/source/functions/BEMIO/plotRadiationIRF.m
+++ b/source/functions/BEMIO/plotRadiationIRF.m
@@ -1,12 +1,16 @@
-function plotRadiationIRF(varargin)
+function plotRadiationIRF(dofList, varargin)
 % Plots the radiation IRF for each hydro structure's bodies in
-% the heave, surge and pitch degrees of freedom.
+% the given degrees of freedom.
 % 
 % Usage:
-% ``plotRadiationIRF(hydro, hydro2, hydro3, ...)``
+% ``plotRadiationIRF([1], hydro, hydro2, hydro3, ...)``
+% ``plotRadiationIRF([1 3 5], hydro, hydro2, hydro3, ...)``
 % 
 % Parameters
 % ----------
+%     dofList : [1 n] int vector
+%         Array of DOFs that will be plotted. Default = [1 3 5]
+%     
 %     varargin : struct(s)
 %         The hydroData structure(s) created by the other BEMIO functions.
 %         One or more may be input.
@@ -17,12 +21,17 @@ if isempty(varargin)
         'structures when calling: plotRadiationIRF(hydro1, hydro2, ...)']);
 end
 
+dofNames = {'Surge','Sway','Heave','Roll','Pitch','Yaw',...
+    'dof7','dof8','dof9','dof10','dof11','dof12'};
+
 figHandle = figure('Position',[50,100,975,521]);
 titleString = ['Normalized Radiation Impulse Response Functions: ',...
     '$$\bar{K}_{i,j}(t) = {\frac{2}{\pi}}\int_0^{\infty}{\frac{B_{i,j}(\omega)}{\rho}}\cos({\omega}t)d\omega$$'];
-subtitleStrings = {'Surge','Heave','Pitch'};
-xString = {'$$t (s)$$','$$t (s)$$','$$t (s)$$'};
-yString = {'$$\bar{K}_{1,1}(t)$$','$$\bar{K}_{3,3}(t)$$','$$\bar{K}_{3,3}(t)$$'};
+subtitleStrings = dofNames(dofList);
+for dof = dofList
+    xString{dof} = '$$t (s)$$';
+    yString{dof} = ['$$\bar{K}_{',num2str(dof),',',num2str(dof),'}(t)$$'];
+end
 
 notes = {'Notes:',...
     ['$$\bullet$$ The IRF should tend towards zero within the specified timeframe. ',...
@@ -42,15 +51,19 @@ for ii = 1:numHydro
     i = 1;
     for iBod = 1:numBod
         m = varargin{ii}.dof(iBod);
-        Y.(tmp2)(1,i,:) = squeeze(varargin{ii}.ra_K(a+1,a+1,:));
-        Y.(tmp2)(2,i,:) = squeeze(varargin{ii}.ra_K(a+3,a+3,:));
-        Y.(tmp2)(3,i,:) = squeeze(varargin{ii}.ra_K(a+5,a+5,:));
+        id = 0;
+        for d = dofList
+            id = id + 1;
+            Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ra_K(a+d,a+d,:));
+        end
         legendStrings{i,ii} = [varargin{ii}.body{iBod}];
         i = i+1;
         if isfield(varargin{ii},'ss_A')==1
-            Y.(tmp2)(1,i,:) = squeeze(varargin{ii}.ss_K(a+1,a+1,:));
-            Y.(tmp2)(2,i,:) = squeeze(varargin{ii}.ss_K(a+3,a+3,:));
-            Y.(tmp2)(3,i,:) = squeeze(varargin{ii}.ss_K(a+5,a+5,:));
+            id = 0;
+            for d = dofList
+                id = id + 1;
+                Y.(tmp2)(id,i,:) = squeeze(varargin{ii}.ss_K(a+d,a+d,:));
+            end
             legendStrings{i,ii} = [varargin{ii}.body{iBod},' (SS)'];
             i = i+1;
         end

--- a/source/functions/BEMIO/readWAMIT.m
+++ b/source/functions/BEMIO/readWAMIT.m
@@ -316,7 +316,7 @@ if exist([tmp{1} '.cfg'],'file')==2
     fclose(fileID);
     N = length(raw);
     for n = 1:N
-        if isempty(strfind(raw{n},'NEWMDS'))==0
+        if isempty(strfind(raw{n},'NEWMDS'))==0 || ~isempty(strfind(raw{n},'IMODESFSP'))
             tmp = strsplit(raw{n},{'(',')','=',' '});
             if raw{n}(7) == '('
                 hydro(F).dof(str2num(tmp{2})) = hydro(F).dof(str2num(tmp{2}))+str2num(tmp{3});


### PR DESCRIPTION
This PR enables users to input custom DOFs into ``plotBEMIO`` and the other BEMIO plotting functions (``plotAddedMass``, ``plotRadiationDamping``, etc).

This allows users to easily visualize sway, roll, yaw or GBM modes. The ``plotBEMIO`` function will use surge, heave, pitch by default if no DOF list is input. If called individually, the BEMIO plotting functions need a ``dofList`` variable defined, e.g.:
    
    plotAddedMass([1 3 5 7],hydro,hydro,hydro)
    plotAddedMass(1,hydro)
Other ways to further expand this could be enabling:
- [ ] off-diagonal added mass and damping terms, [1 3], [3 5], ...
- [ ] non-0 wave headings
