### PR TITLE
readCapytaine_fixes_for_reading_dataformats_correctly

### DIFF
--- a/source/functions/BEMIO/normalizeBEM.m
+++ b/source/functions/BEMIO/normalizeBEM.m
@@ -56,30 +56,30 @@ if issorted(hydro(F).w)==0  % Sort, if necessary
 end
 
 if strcmp(hydro(F).code,'WAMIT')==0  % normalize
-    hydro(F).Khs = hydro(F).Khs/(hydro(F).g*hydro(F).rho);
-    hydro(F).A = hydro(F).A/(hydro(F).rho);
+    hydro(F).Khs = hydro(F).Khs/double(hydro(F).g*hydro(F).rho);
+    hydro(F).A = hydro(F).A/double(hydro(F).rho);
     hydro(F).Ainf = hydro(F).A(:,:,end); % overwritten with more accurate method by radiationIRF.m 
     for i=1:length(hydro(F).w)
-        hydro(F).B(:,:,i) = hydro(F).B(:,:,i)/(hydro(F).rho*hydro(F).w(i));
+        hydro(F).B(:,:,i) = hydro(F).B(:,:,i)/double(hydro(F).rho*hydro(F).w(i));
     end
-    hydro(F).ex_ma = hydro(F).ex_ma/(hydro(F).g*hydro(F).rho);
-    hydro(F).ex_re = hydro(F).ex_re/(hydro(F).g*hydro(F).rho);
-    hydro(F).ex_im = hydro(F).ex_im/(hydro(F).g*hydro(F).rho);
+    hydro(F).ex_ma = hydro(F).ex_ma/double(hydro(F).g*hydro(F).rho);
+    hydro(F).ex_re = hydro(F).ex_re/double(hydro(F).g*hydro(F).rho);
+    hydro(F).ex_im = hydro(F).ex_im/double(hydro(F).g*hydro(F).rho);
     if isfield(hydro(F),'md_mc') 
-        hydro(F).md_mc = hydro(F).md_mc/(hydro(F).g*hydro(F).rho);
+        hydro(F).md_mc = hydro(F).md_mc/double(hydro(F).g*hydro(F).rho);
     end
     if isfield(hydro(F),'md_cs')    
-        hydro(F).md_cs = hydro(F).md_cs/(hydro(F).g*hydro(F).rho);    
+        hydro(F).md_cs = hydro(F).md_cs/double(hydro(F).g*hydro(F).rho);    
     end
     if isfield(hydro(F),'md_pi')
-        hydro(F).md_pi = hydro(F).md_pi/(hydro(F).g*hydro(F).rho);
+        hydro(F).md_pi = hydro(F).md_pi/double(hydro(F).g*hydro(F).rho);
     end        
-    hydro(F).sc_ma = hydro(F).sc_ma/(hydro(F).g*hydro(F).rho);
-    hydro(F).sc_re = hydro(F).sc_re/(hydro(F).g*hydro(F).rho);
-    hydro(F).sc_im = hydro(F).sc_im/(hydro(F).g*hydro(F).rho);
-    hydro(F).fk_ma = hydro(F).fk_ma/(hydro(F).g*hydro(F).rho);
-    hydro(F).fk_re = hydro(F).fk_re/(hydro(F).g*hydro(F).rho);
-    hydro(F).fk_im = hydro(F).fk_im/(hydro(F).g*hydro(F).rho);
+    hydro(F).sc_ma = hydro(F).sc_ma/double(hydro(F).g*hydro(F).rho);
+    hydro(F).sc_re = hydro(F).sc_re/double(hydro(F).g*hydro(F).rho);
+    hydro(F).sc_im = hydro(F).sc_im/double(hydro(F).g*hydro(F).rho);
+    hydro(F).fk_ma = hydro(F).fk_ma/double(hydro(F).g*hydro(F).rho);
+    hydro(F).fk_re = hydro(F).fk_re/double(hydro(F).g*hydro(F).rho);
+    hydro(F).fk_im = hydro(F).fk_im/double(hydro(F).g*hydro(F).rho);
 end
 
 end

--- a/source/functions/BEMIO/readCAPYTAINE.m
+++ b/source/functions/BEMIO/readCAPYTAINE.m
@@ -88,16 +88,7 @@ tmp = ncread(filename,'body_name')';
 for i=1:s1
     hydro(F).body{i} = erase(tmp(i,:), char(0)); % assign preliminary value to body names
 end
-
-hydro(F).body = hydro(F).body{:};
-% Check for newer formatting
-if isstring(hydro(F).body)
-    ncFormat = 'new';
-else 
-    ncFormat = 'old';
-end
-
-hydro(F).body = split(hydro(F).body,'+');
+hydro(F).body = split(hydro(F).body{1},'+');
 
 % sort radiating dof into standard list if necessary
 rdofs = lower(string(ncread(filename,'radiating_dof')'));
@@ -127,26 +118,14 @@ end
 %% Reorder dofs if needed
 % check the ordering of the 'complex' dimension
 tmp = ncread(filename,'complex')';
-if ncFormat == 'new'
-    if tmp(:,1) == "re" && tmp(:,2) == "im"
-        i_re = 1;
-        i_im = 2;
-    elseif tmp(:,1) == "im" && tmp(:,2) == "re"
-        i_im = 1;
-        i_re = 2;
-    else
-        error('Error:BEMIO:Read_Capytaine: check complex dimension indices');
-    end
-elseif ncFormat == 'old'
-    if tmp(1,:) == "re" && tmp(2,:) == "im"
-        i_re = 1;
-        i_im = 2;
-    elseif tmp(1,:) == "im" && tmp(2,:) == "re"
-        i_im = 1;
-        i_re = 2;
-    else
-        error('Error:BEMIO:Read_Capytafe: check complex dimension indices');
-    end
+if tmp{1} == "re" && tmp{2} == "im"
+    i_re = 1;
+    i_im = 2;
+elseif tmp(1,:) == "im" && tmp(2,:) == "re"
+    i_im = 1;
+    i_re = 2;
+else
+    error('Error:BEMIO:Read_Capytaine: check complex dimension indices');
 end
 
 % Check that radiating & influenced dofs are same length and at least 6*Nb


### PR DESCRIPTION
This follows from the closed PR #940 
This PR converts the capytaine generated hydrodynamics coefficients to data formats compatible with wec-sim