### PR TITLE
Remove 'fixed' mass option from OSWEC input file

### DIFF
--- a/examples/OSWEC/wecSimInputFile.m
+++ b/examples/OSWEC/wecSimInputFile.m
@@ -46,7 +46,8 @@ body(1).inertia = [1.85e6 1.85e6 1.85e6];       % Moment of Inertia [kg-m^2]
 % Base
 body(2) = bodyClass('hydroData/oswec.h5');      % Initialize bodyClass for Base
 body(2).geometryFile = 'geometry/base.stl';     % Geometry File
-body(2).mass = 'fixed';                         % Creates Fixed Body
+body(2).mass = 999;                             % Placeholder mass for a fixed body
+body(2).inertia = [999 999 999];                % Placeholder inertia for a fixed body
 
 %% PTO and Constraint Parameters
 % Fixed


### PR DESCRIPTION
This PR addresses a bug where the 'fixed' mass option was still being used for the OSWEC case, causing it to give errors when trying to run. This is only an issue in the dev branch. 

The 'fixed' mass option was removed with PR #856, but the input file to the OSWEC was changed back with [this commit](https://github.com/WEC-Sim/WEC-Sim/commit/51ef9e9322b7c08ea808263443d32092fdaa97db). This PR simply removes the 'fixed' mass and sets the mass and inertia equal to 999.