### PR TITLE
To not tranpose 2D arrays such as Kh and Ainf

### DIFF
--- a/source/functions/BEMIO/reverseDimensionOrder.m
+++ b/source/functions/BEMIO/reverseDimensionOrder.m
@@ -16,8 +16,11 @@ function outputData = reverseDimensionOrder(inputData)
 %         Input data array with the order of its dimensions reversed
 % 
 
-if isnumeric(inputData) && ndims(inputData) > 1
+if isnumeric(inputData) && ndims(inputData) > 2
     outputData = permute(inputData, ndims(inputData):-1:1);
+else
+    outputData = inputData;
 end
 
 end
+


### PR DESCRIPTION
This PR addresses issue #1028 .

Changes made to: 
The reverseDimensionOrder.m function used by readBEMIOh5.m in the functions folder.
---
What the changes do:
 Prevent 2D arrays from being transposed because hydrostatics stiffness matrix is not symmetric.
---
Refer:

![26a19c71-09ed-4d37-81ef-ca6910e82863](https://user-images.githubusercontent.com/84348506/231587058-966982ea-37ef-4435-9f1a-6d15648157e6.jpg)

