### PR TITLE
Fix the transpose of linear restoring matrix to make roll mode rows to be 0

### DIFF
--- a/source/functions/BEMIO/readBEMIOH5.m
+++ b/source/functions/BEMIO/readBEMIOH5.m
@@ -53,7 +53,7 @@ try hydroData.properties.dofEnd   = h5read(filename,[h5BodyName '/properties/dof
 
 % Read hydrostatic stiffness
 hydroData.hydro_coeffs.linear_restoring_stiffness = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/linear_restoring_stiffness']));
-
+hydroData.hydro_coeffs.linear_restoring_stiffness(6:6:end,:) = 0*hydroData.hydro_coeffs.linear_restoring_stiffness(6:6:end,:);
 % Read excitation coefficients and IRF
 hydroData.hydro_coeffs.excitation.re = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/excitation/re']));
 hydroData.hydro_coeffs.excitation.im = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/excitation/im']));

--- a/source/functions/BEMIO/readBEMIOH5.m
+++ b/source/functions/BEMIO/readBEMIOH5.m
@@ -53,7 +53,7 @@ try hydroData.properties.dofEnd   = h5read(filename,[h5BodyName '/properties/dof
 
 % Read hydrostatic stiffness
 hydroData.hydro_coeffs.linear_restoring_stiffness = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/linear_restoring_stiffness']));
-hydroData.hydro_coeffs.linear_restoring_stiffness(6:6:end,:) = 0*hydroData.hydro_coeffs.linear_restoring_stiffness(6:6:end,:);
+hydroData.hydro_coeffs.linear_restoring_stiffness(6,:) = 0*hydroData.hydro_coeffs.linear_restoring_stiffness(6,:);
 % Read excitation coefficients and IRF
 hydroData.hydro_coeffs.excitation.re = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/excitation/re']));
 hydroData.hydro_coeffs.excitation.im = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/excitation/im']));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/84348506/232143996-e76a0a8a-1de3-4ba8-82a1-7d4e45f237ec.png)

The roll mode rows should be 0.
The readBEMIOh5 function uses the permute command to make matrix dimensions compatible to WEC-Sim. This essentially flips the matrix, such that, $X(1:nFreq, b, a)$ becomes $X(a, b, 1:nFreq)$. This works well due to matrix symmetry. However, the roll row for linear restoration matrix must be 0.
This follows from Issue #1028 