### PR TITLE
Update radiationIRF.m

### DIFF
--- a/source/functions/BEMIO/radiationIRF.m
+++ b/source/functions/BEMIO/radiationIRF.m
@@ -71,10 +71,10 @@ ra_Ainf_temp = zeros(length(hydro.w),1);                                    %Ini
 if isempty(hydro.Ainf) == 1 || isfield(hydro,'Ainf') == 0 || strcmp(hydro(F).code,'WAMIT')==0
     for i = 1:sum(hydro.dof)
         for j = 1:sum(hydro.dof)
-            ra_A            = squeeze(hydro.A(i,j,:));
+            ra_A            = interp1(hydro.w,squeeze(hydro.A(i,j,:)),w);
             ra_K            = squeeze(hydro.ra_K(i,j,:));
             for k = 1:length(hydro.w)                                       %Calculate the infinite frequency added mass at each input frequency
-                ra_Ainf_temp(k,1)  = ra_A(k) + (1./hydro.w(k))*trapz(t,ra_K.*sin(hydro.w(k).*t.'));
+                ra_Ainf_temp(k,1)  = ra_A(k) + (1./w(k))*trapz(t,ra_K.*sin(w(k).*t.'));
             end
             hydro.Ainf(i,j) = mean(ra_Ainf_temp);                           %Take the mean across the vector of infinite frequency added mass 
         end


### PR DESCRIPTION
This is a small fix to ensure that the infinite frequency added mass is calculated using the same range of frequencies used to calculate the impulse response function. Working with a user, we realized that the infinite frequency added mass calculation was flawed if there were low or high range of frequencies where the hydrodynamic coefficients were suspect. This arose in a Capytaine run where low frequency behavior impacted the calculation.

I would like to give credit to @ccz359 for helping identify the bug which led to this fix.