### PR TITLE
Normalize quaternion to increase simulation robustness

### DIFF
--- a/source/functions/simulink/model/quaternion2EulXYZ.m
+++ b/source/functions/simulink/model/quaternion2EulXYZ.m
@@ -13,6 +13,7 @@ function E = quaternion2EulXYZ(Q)
 %       E(1) rotation about x, E(2) rotation about y, E(3) rotation about z
 % 
 E = zeros(3,1);
+Q = Q/norm(Q);
 E(1) = atan2((2*(Q(1)*Q(2)+Q(3)*Q(4))), (1-2*(Q(2)^2+Q(3)^2)));
 E(2) = asin(  2*(Q(1)*Q(3)-Q(4)*Q(2)));
 E(3) = atan2((2*(Q(1)*Q(4)+Q(2)*Q(3))), (1-2*(Q(3)^2+Q(4)^2)));


### PR DESCRIPTION
An issue came up in a TEAMER award that uses two cables with spherical joints on all ends. The device motion causes the spherical joints to continuous rotate, causing an increasingly large angular position. This should be allowed to happen with a spherical joint, but our current ``quaternion2EulXYZ`` function will break if the quaternion value becomes too large. 

This PR normalizes the quaternion of any angular rotation in Simulink so that it can be robustly converted to Euler angles.