### PR TITLE
Bugfix resolving documentation build error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## WEC-Sim Repository
 
-* **Docs**: [WEC-Sim documentation](http://wec-sim.github.io/WEC-Sim), to refer to [doc compile instructions](https://github.com/WEC-Sim/WEC-Sim/tree/master/docs/README.md) 
+* **Docs**: [WEC-Sim documentation](http://wec-sim.github.io/WEC-Sim), to refer to [doc compile instructions](https://github.com/WEC-Sim/WEC-Sim/tree/master/docs) 
 * **Examples**: WEC-Sim  examples
 * **Source**: WEC-Sim source code
 * **Tests**: WEC-Sim tests for [MATLAB Continuous Integration](https://www.mathworks.com/solutions/continuous-integration.html)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,5 +15,5 @@ dependencies:
   - sphinxcontrib-bibtex
   - pip:
     - https://github.com/Holzhaus/sphinx-multiversion/archive/refs/heads/master.zip
-    - sphinxcontrib-matlabdomain
+    - sphinxcontrib-matlabdomain < 0.18.0
     - sphinxext-remoteliteralinclude


### PR DESCRIPTION
attempting to resolve https://github.com/WEC-Sim/WEC-Sim/issues/1054 by specifying the version of [sphinxcontrib-matlabdomain < 0.18.0](https://github.com/sphinx-contrib/matlabdomain)