### PR TITLE
Add windows runner to dev branch unit test workflow

### DIFF
--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -2,6 +2,7 @@ name: Run MATLAB tests on dev branch
 on:
   # Trigger the workflow on push or pull request,
   # but only for the dev branch
+  workflow_dispatch: {}
   push:
     branches:
       - dev
@@ -13,23 +14,25 @@ concurrency:
   cancel-in-progress: true
 jobs:
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        release: [R2020b, R2021a, R2021b, latest]
-    name: MATLAB ${{ matrix.release }}
+        release: [R2020b, R2021a, R2021b, R2022a, R2022b, latest]
+        os: [ubuntu-latest, windows-latest]
+    name: MATLAB ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           lfs: true
       - name: Check out LFS objects
         run: git lfs checkout
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2-beta
         with:
-            release: ${{ matrix.release }}
+          release: ${{ matrix.release }}
+          products: Simulink Simscape Simscape_Multibody
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:
@@ -43,3 +46,4 @@ jobs:
             set_param(0, 'ErrorIfLoadNewModel', 'off'),
             results = wecSimTest,
             assertSuccess(results);
+          startup-options: -noFigureWindows


### PR DESCRIPTION
This PR changes the following:

+ Added a Windows runner to the dev branch unit tests workflow by using the beta version of setup-matlab
+ Added untested versions of MATLAB (R2022a, R2022b)
+ Allows the workflow to be triggered manually
