### PR TITLE
Update writeBEMIOH5.m

### DIFF
--- a/source/functions/BEMIO/readBEMIOH5.m
+++ b/source/functions/BEMIO/readBEMIOH5.m
@@ -48,8 +48,8 @@ hydroData.properties.dofEnd   = (number-1)*6+6;
 
 % Update if DOFs included in hydroData
 try hydroData.properties.dof       = h5read(filename,[h5BodyName '/properties/dof']);       end
-try hydroData.properties.dofStart = h5read(filename,[h5BodyName '/properties/dof_start']); end
-try hydroData.properties.dofEnd   = h5read(filename,[h5BodyName '/properties/dof_end']);   end
+try hydroData.properties.dofStart  = h5read(filename,[h5BodyName '/properties/dof_start']); end
+try hydroData.properties.dofEnd    = h5read(filename,[h5BodyName '/properties/dof_end']);   end
 
 % Read hydrostatic stiffness
 hydroData.hydro_coeffs.linear_restoring_stiffness = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/linear_restoring_stiffness']));

--- a/source/functions/BEMIO/writeBEMIOH5.m
+++ b/source/functions/BEMIO/writeBEMIOH5.m
@@ -67,7 +67,7 @@ for i = 1:hydro.Nb
         writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/linear_restoring_stiffness'],tmp(1,m_add + 1:m_add + m,:),'Hydrostatic stiffness','N/m');
         clear tmp;
     else
-        writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/linear_restoring_stiffness'],hydro.Khs(:,:,i),'Hydrostatic stiffness matrix','');        
+        writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/linear_restoring_stiffness'],hydro.Khs(:,:,i)','Hydrostatic stiffness matrix','');        
     end
 
     % Write added mass coefficients


### PR DESCRIPTION
The commit addresses issue #1028 in a better way.
Although, BEMIO was reading the AQWA data correctly, the writeBEMIOH5 did not do the necessary transpose.

BEMIO was reading the AQWA data correctly, but the writeBEMIOH5.m function was not doing the necessary transpose.  
For reference, here is a check that readAQWA function was working correctly.
* In the images that follow, the black background images are from MATLAB, and white background images are from the H5 file viewer.

![image](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/410ead52-7824-44bf-9dcd-8156cda014ce)

However, when I looked at the h5 file in an h5 file viewer, the writeBEMIOH5 function should have taken a transpose.

![image](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/0cd890e0-fd7f-4094-90bc-4567bf800e84)

Following the fix I made, here is how the hydrostatics matrix looks, confirming that the writeBEMIOH5 and readBEMIOH5 are working as intended.

![image](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/554f45fc-54aa-45fb-9872-731cbc9ca3fe)

and here is the h5 file viewer,

![image](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/45d18da3-a433-4215-8e10-f81cef0bf1cf)
