### PR TITLE
fix_readWAMIT_and_writeBEMIOh5

### DIFF
--- a/source/functions/BEMIO/readBEMIOH5.m
+++ b/source/functions/BEMIO/readBEMIOH5.m
@@ -53,7 +53,7 @@ try hydroData.properties.dofEnd   = h5read(filename,[h5BodyName '/properties/dof
 
 % Read hydrostatic stiffness
 hydroData.hydro_coeffs.linear_restoring_stiffness = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/linear_restoring_stiffness']));
-hydroData.hydro_coeffs.linear_restoring_stiffness(6,:) = 0*hydroData.hydro_coeffs.linear_restoring_stiffness(6,:);
+
 % Read excitation coefficients and IRF
 hydroData.hydro_coeffs.excitation.re = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/excitation/re']));
 hydroData.hydro_coeffs.excitation.im = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/excitation/im']));

--- a/source/functions/BEMIO/readWAMIT.m
+++ b/source/functions/BEMIO/readWAMIT.m
@@ -93,6 +93,7 @@ for n = 1:N
         tmp = textscan(raw{n+3}(find(raw{n+3}==':')+1:end),'%f');
         hydro(F).Khs(5,5:6,hydro(F).Nb) = tmp{1};
         hydro(F).Khs(5:6,5,hydro(F).Nb) = tmp{1};
+        hydro(F).Khs(6,:)               = 0*hydro(F).Khs(6,:); % 6th row must be zeros
     end
     if isempty(strfind(raw{n},'Wave period'))==0
         if isempty(strfind(raw{n},'Wave period = infinite'))==0  T = 0;  end

--- a/source/functions/BEMIO/readWAMIT.m
+++ b/source/functions/BEMIO/readWAMIT.m
@@ -92,7 +92,6 @@ for n = 1:N
         hydro(F).Khs(4:5,4,hydro(F).Nb) = tmp{1}(1:2);
         tmp = textscan(raw{n+3}(find(raw{n+3}==':')+1:end),'%f');
         hydro(F).Khs(5,5:6,hydro(F).Nb) = tmp{1};
-        % 6th row must be zeros
     end
     if isempty(strfind(raw{n},'Wave period'))==0
         if isempty(strfind(raw{n},'Wave period = infinite'))==0  T = 0;  end

--- a/source/functions/BEMIO/readWAMIT.m
+++ b/source/functions/BEMIO/readWAMIT.m
@@ -89,11 +89,10 @@ for n = 1:N
         hydro(F).Khs(3:5,3,hydro(F).Nb) = tmp{1};
         tmp = textscan(raw{n+2}(find(raw{n+2}==':')+1:end),'%f');
         hydro(F).Khs(4,4:6,hydro(F).Nb) = tmp{1};
-        hydro(F).Khs(4:6,4,hydro(F).Nb) = tmp{1};
+        hydro(F).Khs(4:5,4,hydro(F).Nb) = tmp{1};
         tmp = textscan(raw{n+3}(find(raw{n+3}==':')+1:end),'%f');
         hydro(F).Khs(5,5:6,hydro(F).Nb) = tmp{1};
-        hydro(F).Khs(5:6,5,hydro(F).Nb) = tmp{1};
-        hydro(F).Khs(6,:)               = 0*hydro(F).Khs(6,:); % 6th row must be zeros
+        % 6th row must be zeros
     end
     if isempty(strfind(raw{n},'Wave period'))==0
         if isempty(strfind(raw{n},'Wave period = infinite'))==0  T = 0;  end

--- a/source/functions/BEMIO/readWAMIT.m
+++ b/source/functions/BEMIO/readWAMIT.m
@@ -89,7 +89,7 @@ for n = 1:N
         hydro(F).Khs(3:5,3,hydro(F).Nb) = tmp{1};
         tmp = textscan(raw{n+2}(find(raw{n+2}==':')+1:end),'%f');
         hydro(F).Khs(4,4:6,hydro(F).Nb) = tmp{1};
-        hydro(F).Khs(4:5,4,hydro(F).Nb) = tmp{1};
+        hydro(F).Khs(4:5,4,hydro(F).Nb) = tmp{1}(1:2);
         tmp = textscan(raw{n+3}(find(raw{n+3}==':')+1:end),'%f');
         hydro(F).Khs(5,5:6,hydro(F).Nb) = tmp{1};
         % 6th row must be zeros

--- a/source/functions/BEMIO/writeBEMIOH5.m
+++ b/source/functions/BEMIO/writeBEMIOH5.m
@@ -67,7 +67,7 @@ for i = 1:hydro.Nb
         writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/linear_restoring_stiffness'],tmp(1,m_add + 1:m_add + m,:),'Hydrostatic stiffness','N/m');
         clear tmp;
     else
-        writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/linear_restoring_stiffness'],hydro.Khs(:,:,i),'Hydrostatic stiffness matrix','');        
+        writeH5Parameter(filename,['/body' num2str(i) '/hydro_coeffs/linear_restoring_stiffness'],hydro.Khs(:,:,i)','Hydrostatic stiffness matrix','');        
     end
 
     % Write added mass coefficients


### PR DESCRIPTION
@nathanmtom 

As mentioned in the last comment for #1063 the fix needs to be done to readWAMIT and writeBEMIOh5.
Here is an illustration.
I modified an .out file to have $(4,6)$ and $(5,6)$ terms. 
![modOut](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/01af026d-d509-43b2-8953-3d2116497b0f)


Here is how readWAMIT would read it to MATLAB workspace,

![readWAMITout](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/3877b279-51c5-4a50-8f47-9db3e089cce0)


I then fixed the readWAMIT to have zeros in the $6^{th}$ row. The readWAMIT function then read the .out file correctly to the MATLAB workspace but the writeBEMIOh5 still automatically does a transpose (perhaps the writing indices are switched in the writing function),

Here is how readWAMIT read the .out file,
![after_readWAMIT_fix](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/2601be08-ae82-471e-a277-0ac0b512c256)

While after the writeBEMIOh5 is done the h5 file is written like this,
![h5File_readWAMIT_fix](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/d3f4b5a4-d597-4637-bd4b-b459ae134a7f)

After having the trasnpose done in the writeBEMIOh5 as well, it can be seen that readWAMIT reads the matrix correctly to the workspace, and the writeBEMIOh5 writes the h5 file correctly,

here is readWAMIT reading the matrix correctly to the workspace,
![after_readWAMIT_and_writeBEMIOh5_fix](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/b9cd7742-093f-4b07-9bb9-3c630a42ba98)


and here is the h5 file correctly written,
![h5_after_readWAMIT_and_writeBEMIOh5_fix](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/d65d7cb9-1adb-4a30-b448-49263db8a118)

