### PR TITLE
Feature paraview

### DIFF
--- a/docs/_include/viz.rst
+++ b/docs/_include/viz.rst
@@ -20,14 +20,14 @@ For more information about using ParaView for visualization, refer to the :ref:`
 
 Install ParaView and WEC-Sim Macros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-First, install `ParaView 5.9.1 <http://www.paraview.org/>`_.  
+First, install `ParaView 5.11.1 <http://www.paraview.org/>`_.  
 Then, add the WEC-Sim specific macros with the following steps:
 
 * Open ParaView
 * Click on ``Macros => Add new macro``
 * Navigate to the WEC-Sim ``source/functions/paraview`` directory
 * Select the first file and click ``OK``
-* Repeat this for all files in the ``source/functions/paraview`` directory
+* Repeat this for all .py files in the ``source/functions/paraview`` directory
 
 
 ParaView Visualization Parameters
@@ -91,19 +91,80 @@ The ``WEC-Sim`` macro:
 
 
 After opening the ``.pvd`` file and running the ``WEC-Sim`` macro you can do a number of things to visualize the simulation in different ways. 
-You can color waves and bodies by any of the available properties and apply any of the ParaView filters.
-The video below shows three different views of the OSWEC model described in the tutorials.
+You can color waves and bodies by any of the available properties and apply any of the ParaView filters. The figures below show some of the visualization possibilities afforded by using ParaView with WEC-Sim.
+
+
+.. |rm3| image:: /_static/images/overview/rm3_iso_side.png
+   :align: middle
+   :width: 400pt
+   :target: https://github.com/WEC-Sim/WEC-Sim/tree/master/examples/RM3
+
+
+.. |oswec| image:: /_static/images/overview/oswec_iso_side.png
+   :align: middle
+   :width: 400pt
+   :target: https://github.com/WEC-Sim/WEC-Sim/tree/master/examples/OSWEC
+
+
+.. |sphere| image:: /_static/images/overview/sphere_freedecay_iso_side.png
+   :align: middle
+   :width: 400pt
+   :target: https://github.com/WEC-Sim/WEC-Sim_Applications/tree/master/Free_Decay
+
+
+.. |ellipsoid| image:: /_static/images/overview/ellipsoid_iso_side.png
+   :align: middle
+   :width: 400pt
+   :target: https://github.com/WEC-Sim/WEC-Sim_Applications/tree/master/Nonlinear_Hydro
+
+
+.. |gbm| image:: /_static/images/overview/gbm_iso_side.png
+   :align: middle
+   :width: 400pt
+   :target: https://github.com/WEC-Sim/WEC-Sim_Applications/tree/master/Generalized_Body_Modes
+
+
+.. |wigley| image:: /_static/images/overview/wigley_iso_side.png
+   :align: middle
+   :width: 400pt
+   :target: https://github.com/WEC-Sim/Wigley
+
+
+.. |wec3| image:: /_static/images/overview/wecccomp_iso_side.png
+   :align: middle
+   :width: 400pt
+   :target: https://github.com/WEC-Sim/WECCCOMP
+
+
+.. |oc6p1| image:: /_static/images/overview/oc6_iso_side.png
+   :align: middle
+   :width: 400pt
+
+
+.. rm3 Reference Model 3
+   oswec Bottom-fixed Oscillating Surge WEC (OSWEC)
+   sphere
+   ellipsoid Ellipsoid
+   gbm Barge with Four Flexible Body Modes
+   wigley Wigley Ship Hull
+   wec3 Wave Energy Converter Control Competition (WECCCOMP) Wavestar Device
+   oc6p1 OC6 Phase I DeepCwind Floating Semisubmersible
+
+
+
+Two examples using Paraview for visualization of WEC-Sim data are provided in the ``Paraview_Visualization`` directory on the `WEC-Sim Applications <https://github.com/WEC-Sim/WEC-Sim_Applications>`_ repository.
+The **RM3_MoorDyn_Viz** example uses ParaView for WEC-Sim data visualization of a WEC-Sim model coupled with `MoorDyn <http://wec-sim.github.io/WEC-Sim/advanced_features.html#moordyn>`_ to simulate a mooring system for the `RM3 <http://wec-sim.github.io/WEC-Sim/tutorials.html#two-body-point-absorber-rm3>`_ geometry.
+The **OSWEC_NonLinear_Viz** example uses ParaView for WEC-Sim data visualization of a WEC-Sim model with `nonlinear Hydro <http://wec-sim.github.io/WEC-Sim/advanced_features.html#nonlinear-buoyancy-and-froude-krylov-excitation>` to simulate nonlinear wave excitation on the flap of the `OSWEC <http://wec-sim.github.io/WEC-Sim/tutorials.html#oscillating-surge-wec-oswec.` geometry.
+
+The video below shows three different views of the RM3 model from the **RM3_MoorDyn_Viz** example.
 The left view uses the WEC-Sim macro.
 The top right view uses the ``slice`` filter.
-The bottom right view shows the free surface colored by wave elevation. 
+The bottom right view shows the free surface colored by wave elevation.
 
 .. raw:: html
 
-	<iframe width="420" height="315" src="https://www.youtube.com/embed/KcsLi38Xjv0" frameborder="0" allowfullscreen></iframe>
+        <iframe width="420" height="315" src="https://www.youtube.com/embed/KcsLi38Xjv0" frameborder="0" allowfullscreen></iframe>
 
-
-An example using Paraview for visualization of WEC-Sim data is provided in the ``Paraview_Visualization`` directory on the `WEC-Sim Applications <https://github.com/WEC-Sim/WEC-Sim_Applications>`_ repository.
-The **RM3_MoorDyn_Viz** example uses ParaView for WEC-Sim data visualization of a WEC-Sim model coupled with [MoorDyn](http://wec-sim.github.io/WEC-Sim/advanced_features.html#moordyn) to simulate a mooring system for the [RM3](http://wec-sim.github.io/WEC-Sim/tutorials.html#two-body-point-absorber-rm3) geometry. 
 
 
 Nonlinear Hydro Visualization in ParaView
@@ -129,11 +190,11 @@ To view WEC-Sim nonlinear hydro data in ParaView:
 * Open the ``$CASE/vtk/<filename>.pvd`` file in ParaView
 * Select the WEC-Sim model in the pipeline, and run the ``WEC-Sim`` macro
 * Move the camera to desired view
-* Select the nonlinear hydro body in the pipeline, and run the ``pressureGlyphs`` macro
+* Select the WEC-Sim model again in the pipeline, and run the ``pressureGlyphs`` macro
 * Select which features to visualize in the pipeline
 * Click the green arrow (play) button
 
-The video below shows three different views of the RM3 model described in the tutorials.
+The video below shows three different views of the OSWEC model described in the tutorials.
 The top right shows glyphs of the nonlinear Froude-Krylov pressure acting on the float. 
 The bottom right shows the float colored by hydrostatic pressure.
 
@@ -143,7 +204,7 @@ The bottom right shows the float colored by hydrostatic pressure.
 
 
 An example using Paraview for visualization of nonlinear hydro WEC-Sim data is provided in the ``Paraview_Visualization`` directory on the `WEC-Sim Applications <https://github.com/WEC-Sim/WEC-Sim_Applications>`_ repository.
-The **OSWEC_NonLinear_Viz** example uses ParaView for WEC-Sim data visualization of a WEC-Sim model with [nonlinear Hydro](http://wec-sim.github.io/WEC-Sim/advanced_features.html#nonlinear-buoyancy-and-froude-krylov-excitation) to simulate nonlinear wave excitation on the flap of the [OSWEC](http://wec-sim.github.io/WEC-Sim/tutorials.html#oscillating-surge-wec-oswec) geometry. 
+The **OSWEC_NonLinear_Viz** example uses ParaView for WEC-Sim data visualization of a WEC-Sim model with `nonlinear Hydro <http://wec-sim.github.io/WEC-Sim/advanced_features.html#nonlinear-buoyancy-and-froude-krylov-excitation>` to simulate nonlinear wave excitation on the flap of the `OSWEC <http://wec-sim.github.io/WEC-Sim/tutorials.html#oscillating-surge-wec-oswec.` geometry. 
 
 Loading a ParaView State File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/_include/viz.rst
+++ b/docs/_include/viz.rst
@@ -194,17 +194,14 @@ To view WEC-Sim nonlinear hydro data in ParaView:
 * Select which features to visualize in the pipeline
 * Click the green arrow (play) button
 
-The video below shows three different views of the OSWEC model described in the tutorials.
+The video below shows three different views of the OSWEC model from the **OSWEC_NonLinear_Viz** example.
 The top right shows glyphs of the nonlinear Froude-Krylov pressure acting on the float. 
-The bottom right shows the float colored by hydrostatic pressure.
+The bottom right shows the device colored by hydrostatic pressure.
 
  .. raw:: html
 
 	<iframe width="420" height="315" src="https://www.youtube.com/embed/VIPXsS8h9pg" frameborder="0" allowfullscreen></iframe>
 
-
-An example using Paraview for visualization of nonlinear hydro WEC-Sim data is provided in the ``Paraview_Visualization`` directory on the `WEC-Sim Applications <https://github.com/WEC-Sim/WEC-Sim_Applications>`_ repository.
-The **OSWEC_NonLinear_Viz** example uses ParaView for WEC-Sim data visualization of a WEC-Sim model with `nonlinear Hydro <http://wec-sim.github.io/WEC-Sim/advanced_features.html#nonlinear-buoyancy-and-froude-krylov-excitation>` to simulate nonlinear wave excitation on the flap of the `OSWEC <http://wec-sim.github.io/WEC-Sim/tutorials.html#oscillating-surge-wec-oswec.` geometry. 
 
 Loading a ParaView State File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/functions/paraview/WEC-Sim.py
+++ b/source/functions/paraview/WEC-Sim.py
@@ -9,7 +9,7 @@ Hide(model, renderView1)
 
 # waves
 extractBlock1 = ExtractBlock(Input=model)
-extractBlock1.BlockIndices = [1, 2]
+extractBlock1.Selectors = ['//*[@cid=%d]'%1, '//*[@cid=%d]'%2]
 extractBlock1Display = Show(extractBlock1, renderView1)
 extractBlock1Display.ColorArrayName = [None, '']
 extractBlock1Display.DiffuseColor = [0.0, 0.0, 1.0]
@@ -43,13 +43,13 @@ RenameSource('ground', plane1)
 # bodies
 filename = dir + os.sep + 'bodies.txt'
 f = open(filename,'r')
-bodies = model.GetDataInformation().GetCompositeDataInformation().GetNumberOfChildren() - 1
+bodies = model.GetDataInformation().GetNumberOfDataSets() - 1
 if MoorDyn:
 	bodies = bodies-1
 for i in range(bodies):
 	SetActiveSource(model)
 	extractBlock1_2 = ExtractBlock(Input=model)
-	extractBlock1_2.BlockIndices = [2+(i*2)+1, 2+(i*2)+2]
+	extractBlock1_2.Selectors = ['//*[@cid=%d]'%(2+(i*2)+1), '//*[@cid=%d]'%(2+(i*2)+2)]
 	extractBlock1_2Display = Show(extractBlock1_2, renderView1)
 	extractBlock1_2Display.ColorArrayName = [None, '']
 	name = f.readline()[:-1]
@@ -65,7 +65,7 @@ f.close()
 if MoorDyn:
 	SetActiveSource(model)
 	extractBlock1_3 = ExtractBlock(Input=model)
-	extractBlock1_3.BlockIndices = [2+((bodies-1)*2)+1+2, 2+((bodies-1)*2)+2+2]
+	extractBlock1_3.Selectors = ['//*[@cid=%d]'%(2+((bodies-1)*2)+1+2), '//*[@cid=%d]'%(2+((bodies-1)*2)+2+2)]
 	extractBlock1_3Display = Show(extractBlock1_3, renderView1)
 	extractBlock1_3Display.ColorArrayName = [None, '']
 	RenameSource('MoorDyn', extractBlock1_3)

--- a/source/functions/paraview/paraviewVisualization.m
+++ b/source/functions/paraview/paraviewVisualization.m
@@ -29,9 +29,15 @@ if simu.paraview.option == 1
             mkdir([simu.paraview.path filesep 'body' num2str(vtkbodiesii) '_' bodyname]);
             TimeBodyParav = output.bodies(ii).time;
             PositionBodyParav = output.bodies(ii).position;
+            if isempty(simu.paraview.startTime)
+                simu.paraview.startTime = simu.startTime;
+            end
+            if isempty(simu.paraview.endTime)
+                simu.paraview.endTime = simu.endTime;
+            end
             NewTimeParaview(:,1) = simu.paraview.startTime:simu.paraview.dt:simu.paraview.endTime;
             PositionBodyParav = interp1(TimeBodyParav,PositionBodyParav,NewTimeParaview);
-            TimeBodyParav = NewTimeParaview-simu.paraview.startTime;
+            TimeBodyParav = NewTimeParaview;
             writeParaviewBody(body(ii), TimeBodyParav, PositionBodyParav, bodyname, modelName, datestr(simu.date), output.bodies(ii).cellPressures_hydrostatic, output.bodies(ii).cellPressures_waveNonLinear, output.bodies(ii).cellPressures_waveLinear, simu.paraview.path,vtkbodiesii);
             bodies{vtkbodiesii} = bodyname;
             fprintf(fid,[bodyname '\n']);

--- a/source/functions/paraview/writeParaviewBody.m
+++ b/source/functions/paraview/writeParaviewBody.m
@@ -81,7 +81,7 @@ for it = 1:length(t)
     % write cell data
     fprintf(fid,'      <CellData>\n');
     % Cell Areas
-    fprintf(fid,'        <DataArray type="Float32" Name="Cell Area" NumberOfComponents="1" format="ascii">\n');
+    fprintf(fid,'        <DataArray type="Float32" Name="CellArea" NumberOfComponents="1" format="ascii">\n');
     for ii = 1:numFace
         fprintf(fid, '          %i', cellareas(ii));
     end
@@ -89,7 +89,7 @@ for it = 1:length(t)
     fprintf(fid,'        </DataArray>\n');
     % Hydrostatic Pressure
     if ~isempty(hspressure)
-        fprintf(fid,'        <DataArray type="Float32" Name="Hydrostatic Pressure" NumberOfComponents="1" format="ascii">\n');
+        fprintf(fid,'        <DataArray type="Float32" Name="HydrostaticPressure" NumberOfComponents="1" format="ascii">\n');
         for ii = 1:numFace
             fprintf(fid, '          %i', hspressure(it,ii));
         end
@@ -98,7 +98,7 @@ for it = 1:length(t)
     end
     % Nonlinear Froude-Krylov Wave Pressure
     if ~isempty(wavenonlinearpressure)
-        fprintf(fid,'        <DataArray type="Float32" Name="Wave Pressure NonLinear" NumberOfComponents="1" format="ascii">\n');
+        fprintf(fid,'        <DataArray type="Float32" Name="WavePressureNonLinear" NumberOfComponents="1" format="ascii">\n');
         for ii = 1:numFace
             fprintf(fid, '          %i', wavenonlinearpressure(it,ii));
         end
@@ -107,7 +107,7 @@ for it = 1:length(t)
     end
     % Linear Froude-Krylov Wave Pressure
     if ~isempty(wavelinearpressure)
-        fprintf(fid,'        <DataArray type="Float32" Name="Wave Pressure Linear" NumberOfComponents="1" format="ascii">\n');
+        fprintf(fid,'        <DataArray type="Float32" Name="WavePressureLinear" NumberOfComponents="1" format="ascii">\n');
         for ii = 1:numFace
             fprintf(fid, '          %i', wavelinearpressure(it,ii));
         end

--- a/source/objects/simulationClass.m
+++ b/source/objects/simulationClass.m
@@ -45,8 +45,8 @@ classdef simulationClass<handle
         nonlinearDt (1,:) {mustBeScalarOrEmpty}         = []                % (`float`) Sample time to calculate nonlinear forces. Default = ``dt``
         paraview (1,1) struct                           = struct(...        % (`structure`) Defines the Paraview visualization.
             'option',                                   0,...               % 
-            'startTime',                                0, ...              %     
-            'endTime',                                  100, ...            % 
+            'startTime',                                [], ...             %
+            'endTime',                                  [], ...             %
             'dt',                                       0.1, ...            % 
             'path',                                     'vtk')              % (`structure`) Defines the Paraview visualization. ``option`` (`integer`) Flag for paraview visualization, and writing vtp files, Options: 0 (off) , 1 (on). Default = ``0``. ``startTime`` (`float`) Start time for the vtk file of Paraview. Default = ``0``. ``endTime`` (`float`) End time for the vtk file of Paraview. Default = ``100``.  ``dt`` (`float`) Timestep for Paraview. Default = ``0.1``. ``path`` (`string`) Path of the folder for Paraview vtk files. Default = ``'vtk'``.      
         pressure (1,1) {mustBeInteger}                  = 0                 % (`integer`) Flag to save pressure distribution, Options: 0 (off), 1 (on). Default = ``0``


### PR DESCRIPTION
Several changes were made to improve visualization with ParaView and make WEC-Sim compatible with Paraview 5.11.1:
- Previously, the script WEC-Sim.py used BlockIndices with ExtractBlock. As of Paraview 5.10, ExtractBlock no longer works with BlockIndices. ExtractBlock was updated to use Selectors instead.
- Previously, the script pressureGlyphs.py could not find the properties it needed (Hydrostatic Pressure, etc.) because whitespace is automatically removed in calculator.Function strings. To resolve this, spaces were removed from the property names in writeParaviewBody.m (eg, HydrostaticPressure).
- The documentation for the ParaView section of user/advanced_features was updated to reflect the current examples in WEC-Sim_Applications. New animations for the two examples will be sent to Kelley to be included in the documentation.
- Previously, simu.paraview.startTime and simu.paraview.endTime were set to 0 and 100 by default in simulationClass.m, which led to the simulation and the visualization running for different amounts of time. This was changed so that they are initialized as empty in simulationClass.m. Then in paraviewVisualization.m, if still empty after reading the input file, they are set to match simu.startTime and simu.endTime, respectively.
- Previously, the displayed times in ParaView were forced to always start at t=0 by subtracting off simu.paraview.startTime in paraviewVisualization.m. This was changed for clarity so that ParaView always refers to the beginning of the simulation as t=0, meaning that the visualization's first time step will always be the same value as simu.paraview.startTime.