### PR TITLE
Fix output order for direct drive PTO

### DIFF
--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -243,8 +243,8 @@ classdef responseClass<handle
                 linearCrankSignals = {'ptoTorque','angPosition','angVelocity'};
                 adjustableRodSignals = {'ptoTorque','angPosition','angVelocity'};
                 checkValveSignals = {'flowCheckValve','deltaPCheckValve'};
-                linearGeneratorSignals = {'absPower','force','fricForce','Ia','Ib','Ic','Va','Vb','Vc','elecPower','vel'};
-                rotaryGeneratorSignals = {'absPower','Torque','fricTorque','Ia','Ib','Ic','Va','Vb','Vc','elecPower','vel'};
+                linearGeneratorSignals = {'absPower','force','fricForce','Ia','Ib','Ic','Va','Vb','Vc','vel','elecPower'};
+                rotaryGeneratorSignals = {'absPower','Torque','fricTorque','Ia','Ib','Ic','Va','Vb','Vc','vel','elecPower'};
 
                 for ii = 1:length(ptosimOutput)
                     %obj.ptoSim(ii).name = ptosimOutput(ii).name;


### PR DESCRIPTION
Output order of direct drive PTO is off and leads to mix-up between electrical power and velocity. 

Note: this is also likely the cause of an old issue: #1033 .