### PR TITLE
readNEMOH update to be compatible with v3.0.0 release (but not QTF)

### DIFF
--- a/source/functions/BEMIO/readNEMOH.m
+++ b/source/functions/BEMIO/readNEMOH.m
@@ -90,17 +90,25 @@ for n = 1:N
         hydro(F).body{b} = tmp{length(tmp)-1};  % Body names
     end
     if isempty(strfind(raw{n},'Number of wave frequencies'))==0
-        try
-            tmp = textscan(raw{n},'%f %f %f');
+        tmp = textscan(raw{n},'%f %f %f %f');
+        if isempty(tmp{end})
             hydro(F).Nf = tmp{1};  % Number of wave frequencies
             hydro(F).w = linspace(tmp{2},tmp{3},tmp{1});  % Wave frequencies
-        catch   %Nemoh v3.0
-            tmp = textscan(raw{n},'%f %f %f %f');                       %added a new %f because of NEMOH3.0 Nemol.cal format change
-            hydro(F).Nf = tmp{2};  % Number of wave frequencies         
-            hydro(F).w = linspace(tmp{3},tmp{4},tmp{2});  % Wave frequencies    
-        end
-        hydro(F).T = 2*pi./hydro(F).w;  % Wave periods
-    end  
+            hydro(F).T = 2*pi./hydro(F).w;  % Wave periods
+        else
+            hydro(F).Nf = tmp{2};  % Number of wave frequencies
+            if tmp{1} == 1
+                hydro(F).w = linspace(tmp{3},tmp{4},tmp{2});  % Wave frequencies
+                hydro(F).T = 2*pi./hydro(F).w;  % Wave periods
+            elseif tmp{1} == 2
+                hydro(F).w = 2*pi*linspace(tmp{3},tmp{4},tmp{2});  % Wave frequencies
+                hydro(F).T = 2*pi./hydro(F).w;  % Wave periods
+            else
+                hydro(F).T = linspace(tmp{3},tmp{4},tmp{2});  % Wave periods
+                hydro(F).w = 2*pi./hydro(F).T;  % Wave frequencies
+            end
+        end   
+    end
     if isempty(strfind(raw{n},'Number of wave directions'))==0
         tmp = textscan(raw{n},'%f %f %f');
         hydro(F).Nh = tmp{1};  % Number of wave headings
@@ -176,7 +184,7 @@ fclose(fileID);
 N = length(raw);
 i = 0;
 for n = 1:N
-    if isempty(strfind(raw{n},'Diffraction force'))==0 || isempty(strfind(raw{n},'Excitation force'))==0;
+    if isempty(strfind(raw{n},'Excitation force'))==0 || isempty(strfind(raw{n},'Diffraction force'))==0
         i = i+1;
         for k = 1:hydro(F).Nf
             tmp = textscan(raw{n+k},'%f');
@@ -363,7 +371,6 @@ end
 waitbar(8/8);
 
 hydro = normalizeBEM(hydro);  % Normalize the data according the WAMIT convention
-hydro = addDefaultPlotVars(hydro);
 
 close(p);
 end

--- a/source/functions/BEMIO/readNEMOH.m
+++ b/source/functions/BEMIO/readNEMOH.m
@@ -371,6 +371,7 @@ end
 waitbar(8/8);
 
 hydro = normalizeBEM(hydro);  % Normalize the data according the WAMIT convention
+hydro = addDefaultPlotVars(hydro);
 
 close(p);
 end


### PR DESCRIPTION
This is an update to reflect changes to the NEMOH input and output files that necessitate an update to readNEMOH. 

Changes are: 

- The NEMOH.cal allows for three options to set wave angular frequency, frequency, or period. An additional column with 1-3 to represent these three choices was added compared to last release. 
- ExcitationForce.tec has changed the name of the header from 'Diffraction force' to 'Excitation force'

The files were updated to be compatible with v3.0.0 release and existing NEMOH files in the WEC-Sim Examples BEMIO folder. 

Note: As it appears NEMOH is providing updates the WEC-Sim team may decide in the future to make readNEMOH only compatible with the latest NEMOH release.
Note: The Examples BEMIO folder need to be updated as changes to the NEMOH.cal and input.txt were made such that the existing input files are incompatible. Placing a project board ticket to update.