### PR TITLE
use capytaine v2 to compute hydrostatics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ docs/_build
 view_html.sh
 *vis-temp*
 *.pyc
+*.nc


### PR DESCRIPTION
added a check:
- if capytaine version < 2.0, still use meshmagick to compute hydrostatics