### PR TITLE
Fix Direct Drive PTO Output order

### DIFF
--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -244,8 +244,8 @@ classdef responseClass<handle
                 linearCrankSignals = {'ptoTorque','angPosition','angVelocity'};
                 adjustableRodSignals = {'ptoTorque','angPosition','angVelocity'};
                 checkValveSignals = {'flowCheckValve','deltaPCheckValve'};
-                linearGeneratorSignals = {'absPower','force','fricForce','Ia','Ib','Ic','Va','Vb','Vc','elecPower','vel'};
-                rotaryGeneratorSignals = {'absPower','Torque','fricTorque','Ia','Ib','Ic','Va','Vb','Vc','elecPower','vel'};
+                linearGeneratorSignals = {'absPower','force','fricForce','Ia','Ib','Ic','Va','Vb','Vc','vel','elecPower'};
+                rotaryGeneratorSignals = {'absPower','Torque','fricTorque','Ia','Ib','Ic','Va','Vb','Vc','vel','elecPower'};
 
                 for ii = 1:length(ptosimOutput)
                     obj.ptosim(ii).name = ptosimOutput(ii).name;


### PR DESCRIPTION
Output order of direct drive PTO is off and leads to mix-up between electrical power and velocity.

Note: this is also likely the cause of an old issue: https://github.com/WEC-Sim/WEC-Sim/issues/1033 .