### PR TITLE
Update readAQWA.m

### DIFF
--- a/source/functions/BEMIO/readAQWA.m
+++ b/source/functions/BEMIO/readAQWA.m
@@ -165,8 +165,7 @@ for ln = n:length(raw1)
                     tmp2 = str2num(raw1{ln+(k-1)*hydro(F).Nh*hydro(F).Nf*2+(j-1)*hydro(F).Nf*2+(i-1)*2+2});
                     ind = tmp1(1:3); tmp1(1:3)=[];
                     hydro(F).ex_ma(((ind(1)-1)*6+1):(ind(1)*6),ind(2),ind(3)) = tmp1; % Magnitude of exciting force
-                    hydro(F).ex_ph(((ind(1)-1)*6+1):(ind(1)*6),ind(2),ind(3)) = wrapToPi(-pi-tmp2*pi/180); % Phase of exciting force    
-                    hydro(F).ex_ph(3,ind(2),ind(3))                           = wrapToPi(-tmp2(3)*pi/180); % Phase of exciting force for heave
+                    hydro(F).ex_ph(((ind(1)-1)*6+1):(ind(1)*6),ind(2),ind(3)) = wrapToPi(-tmp2*pi/180); % Phase of exciting force    
                 end
             end
         end
@@ -277,6 +276,7 @@ for ln=1:length(raw2)
 end
 %%
 hydro = normalizeBEM(hydro);  % Normalize the data according the WAMIT convention
+hydro = addDefaultPlotVars(hydro);
+
 close(p);
-assignin('base','hydro',hydro);
 end


### PR DESCRIPTION
WAMIT/WEC-Sim and AQWA use different conventions to write the wave potential. 
Here is the WEC-Sim convention,

![image](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/f723bc3a-f4d0-41ca-91c3-ef8d6120bfb2)


and here is the AQWA convetion,
![image](https://github.com/WEC-Sim/WEC-Sim/assets/84348506/1df85aa9-b04d-4fe5-ab57-c157f93add08)


The difference in conventions means a negative sign is needed to convert the phase from AQWA to WEC-Sim conventions. However, while previously addressing this issue in #855 an additional phase of pi was being added. 

This was wrong.

After revisiting the PR in issue #1090 it has become clear to me that an additional phase of pi is not needed for non-heave modes. The wrong phase was being added because sample AQWA cases in the WEC-Sim repository had 3 wave headings [-180, 0 , 180], instead of the corresponding WAMIT example that only had 0.

I would like to thank @DeminLiLi @hachikoi1 in helping me identify the issue.

The other issues and threads that are relevant are listed here, so that future referees of those threads are referred to here.  #865 #846 