### PR TITLE
Fix accelerator modes issue

### DIFF
--- a/source/functions/initializeWecSim.m
+++ b/source/functions/initializeWecSim.m
@@ -45,7 +45,7 @@ addpath(fullfile(projectRootDir,'temp'),'-end');
 
 % Save Simulink-generated helper files to 'temp' directory
 Simulink.fileGenControl('set',...
-    'CacheFolder',fullfile(projectRootDir,'temp'))
+    'CacheFolder',fullfile(projectRootDir,''))
 
 
 %% Read input file


### PR DESCRIPTION
This PR attempts to fix the error with the accelerator modes from Issue #1099. It seems to be an issue with the temp folder used to store the accelerator (MEX) files. 

This fix allows the accelerator modes to run without errors. I do not know the intended use-case of the accelerator modes though, so I find it difficult to be sure if they're working as intended.