### PR TITLE
Updating WEC-Sim tests for dev branch

### DIFF
--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [R2020b, R2021a, R2021b, R2022a, R2022b, latest]
+        release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a, latest]
         os: [ubuntu-latest, windows-latest]
     name: MATLAB ${{ matrix.release }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a]
+        release: [R2020b, R2023a]
     name: MATLAB ${{ matrix.release }} on Windows
     steps:
       - name: Check out repository
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a, latest]
+        release: [R2020b, latest]
     name: MATLAB ${{ matrix.release }} on LINUX
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -13,14 +13,46 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  run_tests:
-    runs-on: ${{ matrix.os }}
+  run_windows_tests:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a]
+    name: MATLAB ${{ matrix.release }} on Windows
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+      - name: Check out LFS objects
+        run: git lfs checkout
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v2-beta
+        with:
+          release: ${{ matrix.release }}
+          products: Simulink Simscape Simscape_Multibody
+      - name: Install WEC-Sim
+        uses: matlab-actions/run-command@v1
+        with:
+          command: |
+            addpath(genpath('source')),
+            savepath pathdef.m;
+      - name: Run tests and generate artifacts
+        uses: matlab-actions/run-command@v1
+        with:
+          command: |
+            set_param(0, 'ErrorIfLoadNewModel', 'off'),
+            results = wecSimTest,
+            assertSuccess(results);
+          startup-options: -noFigureWindows
+  run_linux_tests:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a, latest]
-        os: [ubuntu-latest, windows-latest]
-    name: MATLAB ${{ matrix.release }} on ${{ matrix.os }}
+    name: MATLAB ${{ matrix.release }} on LINUX
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
- [x] add MATLAB `2023a` to tests
- [x] remove MATLAB `latest` for windows tests
- [x] only tests `2020b` (earliest) and `latest` version of MATLAB (except for windows until issue is resolved, testing `2023a`)