### PR TITLE
Exclude R2020b and R2021a from Windows test runners

### DIFF
--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -13,13 +13,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  run_windows_tests:
-    runs-on: windows-latest
+  run_tests:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a]
-    name: MATLAB ${{ matrix.release }} on Windows
+        exclude:
+          - os: windows-latest
+            release: R2020b
+          - os: windows-latest
+            release: R2021a
+        include:
+          - os: ubuntu-latest
+            release: latest
+    name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -32,39 +41,7 @@ jobs:
         with:
           release: ${{ matrix.release }}
           products: Simulink Simscape Simscape_Multibody
-      - name: Install WEC-Sim
-        uses: matlab-actions/run-command@v1
-        with:
-          command: |
-            addpath(genpath('source')),
-            savepath pathdef.m;
-      - name: Run tests and generate artifacts
-        uses: matlab-actions/run-command@v1
-        with:
-          command: |
-            set_param(0, 'ErrorIfLoadNewModel', 'off'),
-            results = wecSimTest,
-            assertSuccess(results);
-          startup-options: -noFigureWindows
-  run_linux_tests:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a, latest]
-    name: MATLAB ${{ matrix.release }} on Linux
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Check out LFS objects
-        run: git lfs checkout
-      - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2-beta
-        with:
-          release: ${{ matrix.release }}
-          products: Simulink Simscape Simscape_Multibody
+          cache: true
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           release: ${{ matrix.release }}
           products: Simulink Simscape Simscape_Multibody
-          cache: true
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:

--- a/.github/workflows/run-tests-master.yml
+++ b/.github/workflows/run-tests-master.yml
@@ -13,13 +13,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  run_windows_tests:
-    runs-on: windows-latest
+  run_tests:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a]
-    name: MATLAB ${{ matrix.release }} on Windows
+        exclude:
+          - os: windows-latest
+            release: R2020b
+          - os: windows-latest
+            release: R2021a
+        include:
+          - os: ubuntu-latest
+            release: latest
+    name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -32,39 +41,7 @@ jobs:
         with:
           release: ${{ matrix.release }}
           products: Simulink Simscape Simscape_Multibody
-      - name: Install WEC-Sim
-        uses: matlab-actions/run-command@v1
-        with:
-          command: |
-            addpath(genpath('source')),
-            savepath pathdef.m;
-      - name: Run tests and generate artifacts
-        uses: matlab-actions/run-command@v1
-        with:
-          command: |
-            set_param(0, 'ErrorIfLoadNewModel', 'off'),
-            results = wecSimTest,
-            assertSuccess(results);
-          startup-options: -noFigureWindows
-  run_linux_tests:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a, latest]
-    name: MATLAB ${{ matrix.release }} on Linux
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Check out LFS objects
-        run: git lfs checkout
-      - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2-beta
-        with:
-          release: ${{ matrix.release }}
-          products: Simulink Simscape Simscape_Multibody
+          cache: true
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:

--- a/.github/workflows/run-tests-master.yml
+++ b/.github/workflows/run-tests-master.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           release: ${{ matrix.release }}
           products: Simulink Simscape Simscape_Multibody
-          cache: true
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:


### PR DESCRIPTION
This PR is to exclude R2020b and R2021a from the Windows test runners while they seem to be broken.

Specific changes are:
+ Merged windows and linux jobs, using the matrix to vary version differences
+ Excluded R2020b and R2021a from Windows jobs
+ Include latest in the Linux jobs

EDIT: Opened bug report in `setup-matlab` [#76](https://github.com/matlab-actions/setup-matlab/issues/76).
