### PR TITLE
Remove dead code from wecSim.m

### DIFF
--- a/source/wecSim.m
+++ b/source/wecSim.m
@@ -36,9 +36,6 @@
 %%
 
 % Initialize WEC-Sim
-run('wecSimInputFile');
-clear simu waves body cable pto constraint ptoSim mooring 
-
 runWecSimCML = 1;
 run('initializeWecSim');
 


### PR DESCRIPTION
Minor clean-up. Removes dead code from ``wecSim.m`` to prevent ``wecSimInputFile.m`` from running unnecessarily