### PR TITLE
Update wecSim.m to new MoorDyn dll

### DIFF
--- a/source/functions/postProcessWecSim.m
+++ b/source/functions/postProcessWecSim.m
@@ -128,9 +128,9 @@ clear bodiesOutput ptosOutput constraintsOutput ptosimOutput cablesOutput moorin
 for iMoor = 1:simu.numMoorings
     if mooring(iMoor).moorDyn==1
         % Ensure that Lines library is closed before reading MoorDyn output
-        if libisloaded('Lines')
-            calllib('Lines','LinesClose');
-            unloadlibrary Lines;
+        if libisloaded('libmoordyn')
+            calllib('libmoordyn','MoorDynClose');
+            unloadlibrary libmoordyn;
         end
         
         output.loadMoorDyn(mooring(iMoor).moorDynLines);

--- a/source/wecSim.m
+++ b/source/wecSim.m
@@ -46,9 +46,9 @@ try
     sim(simu.simMechanicsFile, [], simset('SrcWorkspace','parent'));
 catch e % e is an MException struct
     % terminate MoorDyn Conhost.exe instances before the error is thrown
-    if libisloaded('Lines')
-        calllib('Lines','LinesClose');
-        unloadlibrary Lines;
+    if libisloaded('libmoordyn')
+        calllib('libmoordyn','MoorDynClose');
+        unloadlibrary libmoordyn;
     end
 
     % rethrow the error to give the best debugging information


### PR DESCRIPTION
This PR updates wecSim.m to reference the new MoorDyn library (`libmoordyn`) instead of the old one (`Lines`). This is an update that should have been included in the previous MoorDyn updates but was left out by mistake. Discovered in Issue #1171 

This is a bug and should be pushed to both Master and Dev.