### PR TITLE
Correct the phase of excitation force for bodies not situated at the coordinate origin

### DIFF
--- a/source/functions/initializeWecSim.m
+++ b/source/functions/initializeWecSim.m
@@ -281,7 +281,7 @@ idx = find(hydroBodLogic==1);
 if ~isempty(idx)
     for kk = 1:length(idx)
         it = idx(kk);
-        body(it).hydroForcePre(waves(1).omega,waves(1).direction,simu.cicTime,waves(1).bem.count,simu.dt,...
+        body(it).hydroForcePre(waves(1).omega,waves(1).direction,waves(1).wavenumber,simu.cicTime,waves(1).bem.count,simu.dt,...
             simu.rho,simu.gravity,waves(1).type,waves(1).waveAmpTime,simu.stateSpace,simu.b2b);
     end; clear kk idx
 end

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -299,10 +299,11 @@ classdef bodyClass<handle
             obj.dof = length(obj.quadDrag.drag);
         end
         
-        function hydroForcePre(obj,w,direction,cicTime,bemCount,dt,rho,g,waveType,waveAmpTime,stateSpace,B2B)
+        function hydroForcePre(obj,w,direction,wavenumber,cicTime,bemCount,dt,rho,g,waveType,waveAmpTime,stateSpace,B2B)
             % HydroForce Pre-processing calculations
             % 1. Set the linear hydrodynamic restoring coefficient, viscous drag, and linear damping matrices
             % 2. Set the wave excitation force
+            % 3. Correct the phase of excitation force caused by the body not being located at the coordinate origin
             obj.setMassMatrix(rho)
             if (obj.gbmDOF>0)
                 % obj.linearDamping = [obj.linearDamping zeros(1,obj.dof-length(obj.linearDamping))];
@@ -368,6 +369,21 @@ classdef bodyClass<handle
                 obj.hydroForce.gbm.state_space.D = zeros(2*obj.gbmDOF,2*obj.gbmDOF);
                 obj.flex = 1;
                 obj.nonHydro=0;
+            end
+
+            % phase of excitation force correction
+            theta = direction * pi / 180;
+            dphi = -wavenumber * (obj.centerGravity(1) * cos(theta) + obj.centerGravity(2) * sin(theta));
+            c = cos(dphi)'; s = sin(dphi)';
+            fExt_tmp = obj.hydroForce.fExt;
+            if length(w)==1
+                obj.hydroForce.fExt.re = fExt_tmp.re .* c - fExt_tmp.im .* s;
+                obj.hydroForce.fExt.im = fExt_tmp.re .* s + fExt_tmp.im .* c;
+            else
+                for ii = 1:obj.dof
+                    obj.hydroForce.fExt.re(:, :, ii) = fExt_tmp.re(:, :, ii) .* c - fExt_tmp.im(:, :, ii) .* s;
+                    obj.hydroForce.fExt.im(:, :, ii) = fExt_tmp.re(:, :, ii) .* s + fExt_tmp.im(:, :, ii) .* c;
+                end
             end
         end
         


### PR DESCRIPTION
I was recently doing a WEC-array simulation with four bodies being at distinct locations. There should be phase differences in excitation forces, while the simulation indicated that excitation forces have the same phase. The issue lies in that the frequency-domain excitation force data represents the amplitude-phase-frequency characteristics with respect to the wave elevation at the body's COG, while in WEC-Sim excitation force is always calculated using wave elevation at the coordinate origin. This will result in phase errors if the body is not situated at the origin. Therefore, I did this commit to make the frequency-domain excitation force data matching with the origin. A brief readme and a simulation test project are attached. Due to the file format and size restriction, please delete '.zip' in 'test.z01' and 'test.z02' for unzipping the simulation files.
[readme.pdf](https://github.com/WEC-Sim/WEC-Sim/files/13770680/readme.pdf)
[four-body sim test.z01.zip](https://github.com/WEC-Sim/WEC-Sim/files/13770682/four-body.sim.test.z01.zip)
[four-body sim test.z02.zip](https://github.com/WEC-Sim/WEC-Sim/files/13770683/four-body.sim.test.z02.zip)
[four-body sim test.zip](https://github.com/WEC-Sim/WEC-Sim/files/13770686/four-body.sim.test.zip)
