### PR TITLE
Bugfix for plotBEMIO bodies

### DIFF
--- a/source/functions/BEMIO/addDefaultPlotVars.m
+++ b/source/functions/BEMIO/addDefaultPlotVars.m
@@ -18,9 +18,12 @@ function hydro = addDefaultPlotVars(hydro)
 %         Hydro data with default plotting variables.
 % 
 
-hydro.plotDofs = [1,1; 3,3; 5,5];
-hydro.plotBodies = 1:hydro.Nb;
-hydro.plotDirections = 1;
+[a,b] = size(hydro);  % Last data set in
+F = b;
+
+hydro(F).plotDofs = [1,1; 3,3; 5,5];
+hydro(F).plotBodies = 1:hydro(F).Nb;
+hydro(F).plotDirections = 1;
 
 end
 

--- a/source/functions/BEMIO/plotAddedMass.m
+++ b/source/functions/BEMIO/plotAddedMass.m
@@ -37,21 +37,19 @@ notes = {'Notes:',...
 
 numHydro = length(varargin);
 
-for ii = 1:numHydro
-    tmp1 = strcat('X',num2str(ii));
-    X.(tmp1) = varargin{ii}.w;
-    tmp2 = strcat('Y',num2str(ii));
-    for i = 1:length(varargin{ii}.plotBodies)
-        a = 0;
-        if i > 1
-            for i = 2:varargin{ii}.plotBodies(i)
-                a = a + varargin{ii}.dof(varargin{ii}.plotBodies(i-1));
-            end
+for iH = 1:numHydro
+    tmp1 = strcat('X',num2str(iH));
+    X.(tmp1) = varargin{iH}.w;
+    tmp2 = strcat('Y',num2str(iH));
+    for ii = 1:length(varargin{iH}.plotBodies)
+        iB = varargin{iH}.plotBodies(ii);
+        a = sum(varargin{iH}.dof(1:iB)) - varargin{iH}.dof(iB);
+        for iii = 1:size(varargin{iH}.plotDofs,1)
+            iDof1 = a+varargin{iH}.plotDofs(iii,1);
+            iDof2 = a+varargin{iH}.plotDofs(iii,2);
+            Y.(tmp2)(iii,ii,:) = squeeze(varargin{iH}.A(iDof1,iDof2,:));
         end
-        for j = 1:size(varargin{ii}.plotDofs,1)
-            Y.(tmp2)(j,i,:) = squeeze(varargin{ii}.A(a+varargin{ii}.plotDofs(j,1),a+varargin{ii}.plotDofs(j,2),:));
-        end
-        legendStrings{i,ii} = [strcat('hydro_',num2str(ii),'.',varargin{ii}.body{varargin{ii}.plotBodies(i)})];
+        legendStrings{ii,iH} = strcat('hydro_',num2str(iH),'.',varargin{iH}.body{iB});
     end
 end
 

--- a/source/functions/BEMIO/plotExcitationIRF.m
+++ b/source/functions/BEMIO/plotExcitationIRF.m
@@ -38,26 +38,24 @@ notes = {'Notes:',...
 
 numHydro = length(varargin);
 
-for ii = 1:numHydro
-    tmp1 = strcat('X',num2str(ii));
-    X.(tmp1) = varargin{ii}.ex_t;
-    tmp2 = strcat('Y',num2str(ii));
-    b = 0;
-    for i = 1:length(varargin{ii}.plotBodies)
-        a = 0;
-        if i > 1
-            for i = 2:varargin{ii}.plotBodies(i)
-                a = a + varargin{ii}.dof(varargin{ii}.plotBodies(i-1));
+for iH = 1:numHydro
+    tmp1 = strcat('X',num2str(iH));
+    X.(tmp1) = varargin{iH}.ex_t;
+    tmp2 = strcat('Y',num2str(iH));
+    legendCount = 0;
+    for ii = 1:length(varargin{iH}.plotBodies)
+        iB = varargin{iH}.plotBodies(ii);
+        a = sum(varargin{iH}.dof(1:iB)) - varargin{iH}.dof(iB);
+        for iii = 1:size(varargin{iH}.diagPlotDofs,1)
+            iDof = a+varargin{iH}.diagPlotDofs(iii,1);
+            for iv = 1:length(varargin{iH}.plotDirections)
+                iDir = varargin{iH}.plotDirections(iv);
+                tmp3 = strcat('d',num2str(iv));
+                Y.(tmp2).(tmp3)(iii,ii,:) = squeeze(varargin{iH}.ex_K(iDof,iDir,:));
+                legendStrings{legendCount+iv,iH} = strcat('hydro_',num2str(iH),'.',varargin{iH}.body{iB},' \theta =  ',num2str(varargin{iH}.theta(iDir)),'^{\circ}');
             end
         end
-        for j = 1:size(varargin{ii}.diagPlotDofs,1)
-            for k = 1:length(varargin{ii}.plotDirections)
-                tmp3 = strcat('d',num2str(k));
-                Y.(tmp2).(tmp3)(j,i,:) = squeeze(varargin{ii}.ex_K(a+varargin{ii}.diagPlotDofs(j),varargin{ii}.plotDirections(k),:));
-                legendStrings{b+k,ii} = [strcat('hydro_',num2str(ii),'.',varargin{ii}.body{varargin{ii}.plotBodies(i)},' \theta =  ',num2str(varargin{1}.theta(varargin{ii}.plotDirections(k))),'^{\circ}')];
-            end
-        end
-        b = b+k;
+        legendCount = legendCount+iv;
     end
 end
 

--- a/source/functions/BEMIO/plotExcitationMagnitude.m
+++ b/source/functions/BEMIO/plotExcitationMagnitude.m
@@ -32,26 +32,24 @@ notes = {''};
 
 numHydro = length(varargin);
 
-for ii = 1:numHydro
-    tmp1 = strcat('X',num2str(ii));
-    X.(tmp1) = varargin{ii}.w;
-    tmp2 = strcat('Y',num2str(ii));
-    b = 0;
-    for i = 1:length(varargin{ii}.plotBodies)
-        a = 0;
-        if i > 1
-            for i = 2:varargin{ii}.plotBodies(i)
-                a = a + varargin{ii}.dof(varargin{ii}.plotBodies(i-1));
+for iH = 1:numHydro
+    tmp1 = strcat('X',num2str(iH));
+    X.(tmp1) = varargin{iH}.w;
+    tmp2 = strcat('Y',num2str(iH));
+    legendCount = 0;
+    for ii = 1:length(varargin{iH}.plotBodies)
+        iB = varargin{iH}.plotBodies(ii);
+        a = sum(varargin{iH}.dof(1:iB)) - varargin{iH}.dof(iB);
+        for iii = 1:size(varargin{iH}.diagPlotDofs,1)
+            iDof = a+varargin{iH}.diagPlotDofs(iii,1);
+            for iv = 1:length(varargin{iH}.plotDirections)
+                iDir = varargin{iH}.plotDirections(iv);
+                tmp3 = strcat('d',num2str(iv));
+                Y.(tmp2).(tmp3)(iii,ii,:) = squeeze(varargin{iH}.ex_ma(iDof,iDir,:));
+                legendStrings{legendCount+iv,iH} = strcat('hydro_',num2str(iH),'.',varargin{iH}.body{iB},' \theta =  ',num2str(varargin{iH}.theta(iDir)),'^{\circ}');
             end
         end
-        for j = 1:size(varargin{ii}.diagPlotDofs,1)
-            for k = 1:length(varargin{ii}.plotDirections)
-                tmp3 = strcat('d',num2str(k));
-                Y.(tmp2).(tmp3)(j,i,:) = squeeze(varargin{ii}.ex_ma(a+varargin{ii}.diagPlotDofs(j),varargin{ii}.plotDirections(k),:));
-                legendStrings{b+k,ii} = [strcat('hydro_',num2str(ii),'.',varargin{ii}.body{varargin{ii}.plotBodies(i)},' \theta =  ',num2str(varargin{1}.theta(varargin{ii}.plotDirections(k))),'^{\circ}')];
-            end
-        end
-        b = b+k;
+        legendCount = legendCount+iv;
     end
 end
 

--- a/source/functions/BEMIO/plotExcitationPhase.m
+++ b/source/functions/BEMIO/plotExcitationPhase.m
@@ -31,26 +31,24 @@ notes = {''};
 
 numHydro = length(varargin);
 
-for ii = 1:numHydro
-    tmp1 = strcat('X',num2str(ii));
-    X.(tmp1) = varargin{ii}.w;
-    tmp2 = strcat('Y',num2str(ii));
-    b = 0;
-    for i = 1:length(varargin{ii}.plotBodies)
-        a = 0;
-        if i > 1
-            for i = 2:varargin{ii}.plotBodies(i)
-                a = a + varargin{ii}.dof(varargin{ii}.plotBodies(i-1));
+for iH = 1:numHydro
+    tmp1 = strcat('X',num2str(iH));
+    X.(tmp1) = varargin{iH}.w;
+    tmp2 = strcat('Y',num2str(iH));
+    legendCount = 0;
+    for ii = 1:length(varargin{iH}.plotBodies)
+        iB = varargin{iH}.plotBodies(ii);
+        a = sum(varargin{iH}.dof(1:iB)) - varargin{iH}.dof(iB);
+        for iii = 1:size(varargin{iH}.diagPlotDofs,1)
+            iDof = a+varargin{iH}.diagPlotDofs(iii,1);
+            for iv = 1:length(varargin{iH}.plotDirections)
+                iDir = varargin{iH}.plotDirections(iv);
+                tmp3 = strcat('d',num2str(iv));
+                Y.(tmp2).(tmp3)(iii,ii,:) = squeeze(varargin{iH}.ex_ph(iDof,iDir,:));
+                legendStrings{legendCount+iv,iH} = strcat('hydro_',num2str(iH),'.',varargin{iH}.body{iB},' \theta =  ',num2str(varargin{iH}.theta(iDir)),'^{\circ}');
             end
         end
-        for j = 1:size(varargin{ii}.diagPlotDofs,1)
-            for k = 1:length(varargin{ii}.plotDirections)
-                tmp3 = strcat('d',num2str(k));
-                Y.(tmp2).(tmp3)(j,i,:) = squeeze(varargin{ii}.ex_ph(a+varargin{ii}.diagPlotDofs(j),varargin{ii}.plotDirections(k),:));
-                legendStrings{b+k,ii} = [strcat('hydro_',num2str(ii),'.',varargin{ii}.body{varargin{ii}.plotBodies(i)},' \theta =',num2str(varargin{1}.theta(varargin{ii}.plotDirections(k))),'^{\circ}')];
-            end
-        end
-        b = b+k;
+        legendCount = legendCount+iv;
     end
 end
 

--- a/source/functions/BEMIO/plotRadiationDamping.m
+++ b/source/functions/BEMIO/plotRadiationDamping.m
@@ -37,24 +37,19 @@ notes = {'Notes:',...
 
 numHydro = length(varargin);
 
-for ii=1:numHydro
-    tmp1 = strcat('X',num2str(ii));
-    X.(tmp1) = varargin{ii}.w;
-    tmp2 = strcat('Y',num2str(ii));        
-    for i = 1:length(varargin{ii}.plotBodies)
-        a = 0;
-        if i > 1
-            for i = 2:varargin{ii}.plotBodies(i)
-                a = a + varargin{ii}.dof(varargin{ii}.plotBodies(i-1));
-            end
+for iH = 1:numHydro
+    tmp1 = strcat('X',num2str(iH));
+    X.(tmp1) = varargin{iH}.w;
+    tmp2 = strcat('Y',num2str(iH));
+    for ii = 1:length(varargin{iH}.plotBodies)
+        iB = varargin{iH}.plotBodies(ii);
+        a = sum(varargin{iH}.dof(1:iB)) - varargin{iH}.dof(iB);
+        for iii = 1:size(varargin{iH}.plotDofs,1)
+            iDof1 = a+varargin{iH}.plotDofs(iii,1);
+            iDof2 = a+varargin{iH}.plotDofs(iii,2);
+            Y.(tmp2)(iii,ii,:) = squeeze(varargin{iH}.B(iDof1,iDof2,:));
         end
-        if i ~= 1
-            a = (varargin{ii}.plotBodies(i)-1)*varargin{ii}.dof(varargin{ii}.plotBodies(i-1));
-        end
-        for j = 1:size(varargin{ii}.plotDofs,1)
-            Y.(tmp2)(j,i,:) = squeeze(varargin{ii}.B(a+varargin{ii}.plotDofs(j,1),a+varargin{ii}.plotDofs(j,2),:));
-        end
-        legendStrings{i,ii} = [strcat('hydro_',num2str(ii),'.',varargin{ii}.body{varargin{ii}.plotBodies(i)})];
+        legendStrings{ii,iH} = strcat('hydro_',num2str(iH),'.',varargin{iH}.body{iB});
     end
 end
 

--- a/source/functions/BEMIO/plotRadiationIRF.m
+++ b/source/functions/BEMIO/plotRadiationIRF.m
@@ -38,30 +38,28 @@ notes = {'Notes:',...
 
 numHydro = length(varargin);
 
-for ii = 1:numHydro
-    tmp1 = strcat('X',num2str(ii));
-    X.(tmp1) = varargin{ii}.ra_t;
-    tmp2 = strcat('Y',num2str(ii));
-    q = 0;
-    for i = 1:length(varargin{ii}.plotBodies)
-        a = 0;
-        if i > 1
-            for i = 2:varargin{ii}.plotBodies(i)
-                a = a + varargin{ii}.dof(varargin{ii}.plotBodies(i-1));
+for iH = 1:numHydro
+    tmp1 = strcat('X',num2str(iH));
+    X.(tmp1) = varargin{iH}.ra_t;
+    tmp2 = strcat('Y',num2str(iH));
+    ssFlag = isfield(varargin{iH},'ss_A');
+    for ii = 1:length(varargin{iH}.plotBodies)
+        iB = varargin{iH}.plotBodies(ii);
+        a = sum(varargin{iH}.dof(1:iB)) - varargin{iH}.dof(iB);
+        for iii = 1:size(varargin{iH}.plotDofs,1)
+            iDof1 = a+varargin{iH}.plotDofs(iii,1);
+            iDof2 = a+varargin{iH}.plotDofs(iii,2);
+            if ssFlag
+                Y.(tmp2)(iii,ii,:) = squeeze(varargin{iH}.ss_K(iDof1,iDof2,:));
+            else
+                Y.(tmp2)(iii,ii,:) = squeeze(varargin{iH}.ra_K(iDof1,iDof2,:));
             end
         end
-        for j = 1:size(varargin{ii}.plotDofs,1)
-            Y.(tmp2)(j,i,:) = squeeze(varargin{ii}.ra_K(a+varargin{ii}.plotDofs(j,1),a+varargin{ii}.plotDofs(j,2),:));
-            if isfield(varargin{ii},'ss_A')==1
-                q = 1;
-                Y.(tmp2)(j,i,:) = squeeze(varargin{ii}.ss_K(a+varargin{ii}.plotDofs(j,1),a+varargin{ii}.plotDofs(j,2),:));
-            end
+        if ssFlag
+            legendStrings{ii,iH} = strcat('hydro_',num2str(iH),'.',varargin{iH}.body{iB},' (SS)');
+        else
+            legendStrings{ii,iH} = strcat('hydro_',num2str(iH),'.',varargin{iH}.body{iB});
         end
-        legendStrings{i,ii} = [strcat('hydro_',num2str(ii),'.',varargin{ii}.body{varargin{ii}.plotBodies(i)})];
-        if q == 1
-            legendStrings{i,ii} = [strcat('hydro_',num2str(ii),'.',varargin{ii}.body{varargin{ii}.plotBodies(i)}),' (SS)'];
-        end
-        q = 0;
     end
 end
 


### PR DESCRIPTION
The BEMIO plotting functions were not handling DOFs correctly when not all bodies were being input. 
e.g. ``hydro.plotBodies = 2``, then the first body was still being plotted

This PR fixes the logic in each plotting function to accurately plot the hydrodata of bodies called out in hydro.plotBodies, regardless of body order. I also updated some of the looping variables to be more meaningful so that the functions are a bit easier to follow. e.g. ``iB`` for body index, ``iDof`` for DOF index, etc
