### PR TITLE
Updating tests on main and dev

### DIFF
--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        release: [R2022a, R2022b, R2023a, R2023b, 2024a]
+        release: [2021b, R2022a, R2022b, R2023a, R2023b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -19,10 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a, R2023b]
-        exclude:
-          - os: windows-latest
-            release: R2020b
+        release: [R2022a, R2022b, R2023a, R2023b, 2024a]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        release: [2021b, R2022a, R2022b, R2023a, R2023b]
+        release: [R2022a, R2022b, R2023a, R2023b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-main.yml
+++ b/.github/workflows/run-tests-main.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        release: [R2022a, R2022b, R2023a, R2023b, 2024a]
+        release: [2021b, R2022a, R2022b, R2023a, R2023b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-main.yml
+++ b/.github/workflows/run-tests-main.yml
@@ -19,10 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        release: [R2020b, R2021a, R2021b, R2022a, R2022b, R2023a, R2023b]
-        exclude:
-          - os: windows-latest
-            release: R2020b
+        release: [R2022a, R2022b, R2023a, R2023b, 2024a]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-main.yml
+++ b/.github/workflows/run-tests-main.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        release: [2021b, R2022a, R2022b, R2023a, R2023b]
+        release: [R2022a, R2022b, R2023a, R2023b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -18,7 +18,7 @@ Simscape                    Version 5.0  (R2020b)
 Simscape Multibody          Version 7.2  (R2020b)
 ==========================  =============================
 
-WEC-Sim's Simulink Library is saved in MATLAB R2020b, and WEC-Sim tests are run on the last five releases of MATLAB. 
+WEC-Sim's Simulink Library is saved in MATLAB R2020b, and WEC-Sim tests are run on the last four releases of MATLAB. 
 Any version of MATLAB newer than R2020b should be compatible with WEC-Sim, however we do not test all MATLAB releases. 
 The stability of each MATLAB release is available via `WEC-Sim's GitHub Actions <https://github.com/WEC-Sim/WEC-Sim/actions>`_. 
 Certain advanced features rely on external functions (such as :ref:`mooring-moordyn`), and additional MATLAB Toolboxes (such as :ref:`user-advanced-features-pct`). 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -18,8 +18,8 @@ Simscape                    Version 5.0  (R2020b)
 Simscape Multibody          Version 7.2  (R2020b)
 ==========================  =============================
 
-WEC-Sim's Simulink Library is saved in MATLAB R2020b, and WEC-Sim tests are run on MATLAB R2020b and newer. 
-Any version of MATLAB newer than R2020b should be compatible with WEC-Sim. 
+WEC-Sim's Simulink Library is saved in MATLAB R2020b, and WEC-Sim tests are run on the last five releases of MATLAB. 
+Any version of MATLAB newer than R2020b should be compatible with WEC-Sim, however we do not test all MATLAB releases. 
 The stability of each MATLAB release is available via `WEC-Sim's GitHub Actions <https://github.com/WEC-Sim/WEC-Sim/actions>`_. 
 Certain advanced features rely on external functions (such as :ref:`mooring-moordyn`), and additional MATLAB Toolboxes (such as :ref:`user-advanced-features-pct`). 
 


### PR DESCRIPTION
This PR updates the WEC-Sim tests on main and dev to only include the last 5 MATLAB releases:
- 2022a
- 2022b
- 2023a
- 2023b
- 2024a

This will officially decouple the WEC-Sim testing from the MATLAB version used to save the WEC-Sim library. 