### PR TITLE
[BUG] Update readAQWA to fix excitation phase and b2b loading issues - main branch

### DIFF
--- a/source/functions/BEMIO/readAQWA.m
+++ b/source/functions/BEMIO/readAQWA.m
@@ -104,6 +104,14 @@ for ln = n:length(raw1)
             hydro(F).g      = tmp(3);   % Gravity
         end
         clear V182
+        % Set water depth conditions for calculating wavenumber later
+        if hydro(F).h == inf || hydro(F).h >= 200
+            deepWater = 1;
+            waterDepth = 200;
+        else
+            deepWater = 0;
+            waterDepth = hydro(F).h;
+        end
     end
     if isempty(strfind(raw1{ln},'COG'))==0
         for i=1:hydro(F).Nb
@@ -144,9 +152,9 @@ for ln = n:length(raw1)
                         if isempty(tmp) flag = 1; break; end % if temp variable is empty, exit loops
                         if length(tmp)>6 ind = tmp(1:3); tmp(1:3)=[]; end
                         if f==0 % Added Mass
-                            hydro(F).A((ind(2)-1)*6+i,((ind(1)-1)*6+1):(ind(1)*6),ind(3)) = tmp;
+                            hydro(F).A((ind(1)-1)*6+i,((ind(2)-1)*6+1):(ind(2)*6),ind(3)) = tmp;
                         elseif f==1 % Radiation Damping
-                            hydro(F).B((ind(2)-1)*6+i,((ind(1)-1)*6+1):(ind(1)*6),ind(3)) = tmp;
+                            hydro(F).B((ind(1)-1)*6+i,((ind(2)-1)*6+1):(ind(2)*6),ind(3)) = tmp;
                         end
                         if flag == 1 break; end
                     end
@@ -165,7 +173,13 @@ for ln = n:length(raw1)
                     tmp2 = str2num(raw1{ln+(k-1)*hydro(F).Nh*hydro(F).Nf*2+(j-1)*hydro(F).Nf*2+(i-1)*2+2});
                     ind = tmp1(1:3); tmp1(1:3)=[];
                     hydro(F).ex_ma(((ind(1)-1)*6+1):(ind(1)*6),ind(2),ind(3)) = tmp1; % Magnitude of exciting force
-                    hydro(F).ex_ph(((ind(1)-1)*6+1):(ind(1)*6),ind(2),ind(3)) = wrapToPi(-tmp2*pi/180); % Phase of exciting force    
+                    % AQWA measures phase with respect to the cog of each
+                    % body. For WEC-Sim, we need to convert the phase to be
+                    % relative to the global origin.
+                    wavenumber = calcWaveNumber(hydro(F).w(i),waterDepth,hydro(F).g,deepWater);
+                    hydro(F).ex_ph(((ind(1)-1)*6+1):(ind(1)*6),ind(2),ind(3)) = wrapToPi(-tmp2*pi/180 ...
+                        - wavenumber*(hydro(F).cg(1,k).*cos(hydro(F).theta(j)*pi/180) + ...
+                        hydro(F).cg(2,k).*sin(hydro(F).theta(j)*pi/180))); % Phase of exciting force    
                 end
             end
         end
@@ -227,7 +241,10 @@ for ln=1:length(raw2)
                 tmp2 = tmp1(2:2:end);
                 tmp1(2:2:end)=[];
                 hydro(F).fk_ma((k-1)*6+1:k*6,j,i) = tmp1;  % mag of froude Krylov force
-                hydro(F).fk_ph((k-1)*6+1:k*6,j,i) = tmp2;  % phase of froude Krylov force
+                wavenumber = calcWaveNumber(hydro(F).w(i),waterDepth,hydro(F).g,deepWater);
+                hydro(F).fk_ph((k-1)*6+1:k*6,j,i) = wrapToPi(-tmp2*pi/180 ...
+                        - wavenumber*(hydro(F).cg(1,k).*cos(hydro(F).theta(j)*pi/180) + ...
+                        hydro(F).cg(2,k).*sin(hydro(F).theta(j)*pi/180))); % Phase of Froude Krylov force
             end
         end        
         hydro(F).fk_re = hydro(F).fk_ma.*cos(hydro(F).fk_ph*pi/180); % real part of Froude Krylov force
@@ -262,7 +279,10 @@ for ln=1:length(raw2)
                 tmp2 = tmp1(2:2:end);
                 tmp1(2:2:end)=[];
                 hydro(F).sc_ma((kdiff-1)*6+1:kdiff*6,j,i) = tmp1;  % mag of scattering force
-                hydro(F).sc_ph((kdiff-1)*6+1:kdiff*6,j,i) = tmp2;  % phase of scattering force
+                wavenumber = calcWaveNumber(hydro(F).w(i),waterDepth,hydro(F).g,deepWater);
+                hydro(F).sc_ph((kdiff-1)*6+1:kdiff*6,j,i) = wrapToPi(-tmp2*pi/180 ...
+                        - wavenumber*(hydro(F).cg(1,k).*cos(hydro(F).theta(j)*pi/180) + ...
+                        hydro(F).cg(2,k).*sin(hydro(F).theta(j)*pi/180))); % Phase of scattering force
             end
         end        
         hydro(F).sc_re = hydro(F).sc_ma.*cos(hydro(F).sc_ph*pi/180); % real part of scattering force


### PR DESCRIPTION
This PR fixes 2 bugs in the readAQWA.m script to resolve #1116 :
1. The excitation phase in Ansys AQWA is given relative to the center of gravity of each body and a positive phase angle represents the excitation lagging behind the wave.

<img src="https://github.com/WEC-Sim/WEC-Sim/assets/87095491/e973775c-4c64-4799-9705-977027481927" width="500">

On the other hand, WEC-Sim follows WAMIT's standard, which is to define the excitation phase relative to the global origin and a positive phase angle meaning the excitation leading the wave.

<img src="https://github.com/WEC-Sim/WEC-Sim/assets/87095491/3fe3c6a4-2eff-4f6a-a2b0-344fdae734b3" width="500">

The current readAQWA.m script negates the phase correctly to adjust to the discrepancy in leading/lagging, but does not take into account the difference in reference frames. Thus, WEC-Sim does not apply the correct excitation phase when using AQWA and a body is not located at the global origin. I updated the readAQWA.m script to adjust the phase of the excitation coefficients upon loading them into the hydro structure. This approach uses the equation (k is wave number, x and y are the coordinates of the body's cg, and $\beta$ is the wave direction): 
$\Theta_{WAMIT} = -\Theta_{AQWA} - k  [x  cos(\beta) + y  sin(\beta)]$

To demonstrate the difference, I used the example from PR #1191 and ran a 4 cylinder (locations: [-8, -8], [-8, 8], [8, -8], [8, 8]) case in both AQWA (blue, hydro_1) and Capytaine (orange, hydro_2) and compared the results. Before the updates in this PR, the excitation phase was significantly different, while after the updates in this PR, the results show much better match:

Before: <img src="https://github.com/WEC-Sim/WEC-Sim/assets/87095491/31f54d32-3331-4c06-a5d6-80e9e1f36649" width="320"> After PR: <img src="https://github.com/WEC-Sim/WEC-Sim/assets/87095491/4169a517-6f42-4a98-8e39-2e181112a414" width="320">

2. The body-to-body elements of the added mass and radiation damping matrices were being read in backwards. When looking at the AH1 output file, each added mass and radiation damping matrix has 3 leading numbers (first 2 related to the body interactions and last number related to the frequency number). When outputting the AH1 descriptions, AQWA states that `"  1  1" (i3,i3) means the force on structure 1 caused by the motions of structure 1.` Thus, I interpret this as the 1st number representing the body on which the forces act and the 2nd number being the body causing the forces. When we load these values into WEC-Sim and turn on b2b, it is clear that the interactions are being read in backwards. From AQWA RM3 case, the force on body 1 from body 2 (frequency 1) should have elements: 

<img src="https://github.com/WEC-Sim/WEC-Sim/assets/87095491/93bbe0cf-2a4a-4070-8f45-bdb23c1687f9" width="320">

But, with simu.b2b = 1, the body-body interaction terms for the force on body 1 from body 2 (frequency 1) are slightly different: 

<img src="https://github.com/WEC-Sim/WEC-Sim/assets/87095491/7e6e7c05-c44e-4ce2-aadf-4a8658d9f227" width="320">

When looking at the opposite terms (force on body 2 from body 1) as well, it is clear that the interaction terms are backwards. 

AQWA output: <img src="https://github.com/WEC-Sim/WEC-Sim/assets/87095491/36ac85b4-34a0-4d83-b15e-4294d2cffef3" width="320">

WEC-Sim Forces: <img src="https://github.com/WEC-Sim/WEC-Sim/assets/87095491/f90b3483-1888-4aa6-948d-e0bc542cb6b1" width="320">

To put it more plainly, readAQWA originally loaded the added mass and radiation damping terms as in eq. 7 below, while this PR corrects it to be as eq. 8. 

<img width="320" alt="image" src="https://github.com/WEC-Sim/WEC-Sim/assets/87095491/7a2063b5-ad06-4d80-9207-9043e3d43c00">


Some additional useful references include [this paper on a 2 body hinged raft WEC](https://www.sciencedirect.com/science/article/pii/S0029801822025690?ref=pdf_download&fr=RR-2&rr=87e20e333c4be8fd#appsec1) which uses WEC-Sim but demonstrates the two readAQWA.m updates which were needed to correct their results and issue #1116 where both issues are explained as well. 

Thank you to @hachikoi1 and @meatballgithub for recognizing these issues and helping us solve them.