### PR TITLE
Update readCAPYTAINE.m to read Khs from .nc

### DIFF
--- a/source/functions/BEMIO/readCAPYTAINE.m
+++ b/source/functions/BEMIO/readCAPYTAINE.m
@@ -218,7 +218,7 @@ for m = 1:hydro(F).Nb
         raw = textscan(fileID,'%[^\n\r]');
         raw = raw{:};
         fclose(fileID);
-        for i=1:6
+        for i = 1:6
             tmp = textscan(raw{i},'%f');
             hydro(F).Khs(i,:,m) = tmp{1,1}(1:6);  % Linear restoring stiffness
         end
@@ -231,12 +231,11 @@ end
 for m = 1:hydro(F).Nb
    try
         Khs_all = ncread(filename,'hydrostatic_stiffness');
-        for i=1:6
-        hydro(F).Khs(i,:,m) = Khs_all((m-1)*6+i,(m-1)*6+1:(m-1)*6+6);
-        
+        for i = 1:6
+            hydro(F).Khs(i,:,m) = Khs_all((m-1)*6+i,(m-1)*6+1:(m-1)*6+6);
         end
    catch
-            warning('Hydrostatics data not found in either .nc nor as a .dat file!')
+        warning('Hydrostatics data not found in either .nc nor as a .dat file!');
    end
 
 end

--- a/source/functions/BEMIO/readCAPYTAINE.m
+++ b/source/functions/BEMIO/readCAPYTAINE.m
@@ -175,7 +175,7 @@ for m = 1:hydro(F).Nb
     if hydro(F).Nb == 1
         fileID = fopen(fullfile(hydrostatics_dir,'Hydrostatics.dat'));
     else
-        fileID = fopen([fullfile(hydrostatics_dir,'Hydrostatics'),num2str(m-1),'.dat']);
+        fileID = fopen([fullfile(hydrostatics_dir,'Hydrostatics_'),num2str(m-1),'.dat']);
     end
     
     if fileID ~= -1

--- a/source/functions/BEMIO/readCAPYTAINE.m
+++ b/source/functions/BEMIO/readCAPYTAINE.m
@@ -227,6 +227,19 @@ for m = 1:hydro(F).Nb
         hydro(F).Khs = zeros(6,6,hydro(F).Nb);
     end
 end
+
+for m = 1:hydro(F).Nb
+   try
+        Khs_all = ncread(filename,'hydrostatic_stiffness');
+        for i=1:6
+        hydro(F).Khs(i,:,m) = Khs_all((m-1)*6+i,(m-1)*6+1:(m-1)*6+6);
+        
+        end
+   catch
+            warning('Hydrostatics data not found in either .nc nor as a .dat file!')
+   end
+
+end
 waitbar(3/8);
 
 %% Radiation added mass [6*Nb, 6*Nb, Nf]


### PR DESCRIPTION
Latest version of capytaine writes hydrostatics data in the .nc file. This PR adds some code to read the hydrostatics data directly from the .nc file and removes the need to have a separate function that first writes a .dat file in python.

