### PR TITLE
Expand regression tests

### DIFF
--- a/tests/regressionTest.m
+++ b/tests/regressionTest.m
@@ -38,6 +38,16 @@ classdef regressionTest < matlab.unittest.TestCase
     
     methods(TestClassSetup)
         
+        function runBEMIO(testCase)
+            cd(fullfile(testCase.testDir,...
+                        '..',...
+                        'examples',...
+                        'RM3',...
+                        'hydroData'));
+            bemio
+            cd(testCase.testDir);
+        end
+
         function runRegTest(testCase)            
             cd(fullfile(testCase.testDir,       ...
                         'RegressionTests',      ...
@@ -45,8 +55,8 @@ classdef regressionTest < matlab.unittest.TestCase
                         'regular'))            
             runLoadRegular;
             testCase.regular = load('regular.mat').("regular");
-            savefig(fullfile('..', 'figReg'));            
-            cd(testCase.testDir);            
+            savefig(fullfile('..', 'figReg'));
+            cd(testCase.testDir);
         end
         
         function runRegCICTest(testCase)            

--- a/tests/regressionTest.m
+++ b/tests/regressionTest.m
@@ -14,18 +14,18 @@ classdef regressionTest < matlab.unittest.TestCase
     
     methods(Access = 'public')
         
-        function obj = regressionTest(plotSolvers, openCompare)            
+        function obj = regressionTest(plotSolvers, openCompare)
             arguments
                 plotSolvers (1,1) double = 1
                 openCompare (1,1) double = 1
-            end            
+            end
             % Assign arguments to test Class
             obj.plotSolvers = plotSolvers;
-            obj.openCompare = openCompare;            
+            obj.openCompare = openCompare;
             % Set test directory
-            obj.testDir = fileparts(mfilename('fullpath'));            
+            obj.testDir = fileparts(mfilename('fullpath'));
             % Save the visibility state at construction
-            obj.OriginalDefault = get(0,'DefaultFigureVisible');            
+            obj.OriginalDefault = get(0,'DefaultFigureVisible');
         end
         
     end
@@ -48,95 +48,95 @@ classdef regressionTest < matlab.unittest.TestCase
             cd(testCase.testDir);
         end
 
-        function runRegTest(testCase)            
+        function runRegTest(testCase)
             cd(fullfile(testCase.testDir,       ...
                         'RegressionTests',      ...
                         'RegularWaves',         ...
-                        'regular'))            
+                        'regular'))
             runLoadRegular;
             testCase.regular = load('regular.mat').("regular");
             savefig(fullfile('..', 'figReg'));
             cd(testCase.testDir);
         end
         
-        function runRegCICTest(testCase)            
+        function runRegCICTest(testCase)
             cd(fullfile(testCase.testDir,       ...
                         'RegressionTests',      ...
                         'RegularWaves',         ...
-                        'regularCIC'))            
+                        'regularCIC'))
             runLoadRegularCIC;
             testCase.regularCIC = load('regularCIC.mat').("regularCIC");
-            savefig(fullfile('..', 'figRegCIC'));            
-            cd(testCase.testDir);            
+            savefig(fullfile('..', 'figRegCIC'));
+            cd(testCase.testDir);
         end
         
-        function runRegSSTest(testCase)            
+        function runRegSSTest(testCase)
             cd(fullfile(testCase.testDir,       ...
                         'RegressionTests',      ...
                         'RegularWaves',         ...
-                        'regularSS'))            
+                        'regularSS'))
             runLoadRegularSS;
             testCase.regularSS = load('regularSS.mat').("regularSS");
-            savefig(fullfile('..', 'figRegSS'));            
-            cd(testCase.testDir);        
+            savefig(fullfile('..', 'figRegSS'));
+            cd(testCase.testDir);
         end
         
-        function runIrregCICTest(testCase)            
+        function runIrregCICTest(testCase)
             cd(fullfile(testCase.testDir,   ...
                         'RegressionTests',  ...
                         'IrregularWaves',   ...
-                        'irregularCIC'))                    
+                        'irregularCIC'))
             runLoadIrregularCIC;
             testCase.irregularCIC = ...
                                 load('irregularCIC.mat').("irregularCIC");
-            savefig(fullfile('..', 'figIrregCIC'));            
-            cd(testCase.testDir);            
+            savefig(fullfile('..', 'figIrregCIC'));
+            cd(testCase.testDir);
         end
         
-        function runIrregSSTest(testCase)            
+        function runIrregSSTest(testCase)
             cd(fullfile(testCase.testDir,   ...
                         'RegressionTests',  ...
                         'IrregularWaves',   ...
-                        'irregularSS'))                    
+                        'irregularSS'))
             runLoadIrregularSS;
             testCase.irregularSS = load('irregularSS.mat').("irregularSS");
-            savefig(fullfile('..', 'figIrregSS'));            
-            cd(testCase.testDir);            
+            savefig(fullfile('..', 'figIrregSS'));
+            cd(testCase.testDir);
         end
         
     end
     
     methods(TestClassTeardown)
         
-        function plotRegTests(testCase)            
+        function plotRegTests(testCase)
             % Plot Solver Comparisons
-            if testCase.plotSolvers == 1                
+            if testCase.plotSolvers == 1
                 cd(fullfile(testCase.testDir,   ...
                             'RegressionTests',  ...
                             'RegularWaves'));
-                printPlotRegular;                
+                printPlotRegular;
                 cd(fullfile(testCase.testDir,   ...
                             'RegressionTests',  ...
                             'IrregularWaves'));
-                printPlotIrregular;                
+                printPlotIrregular;
             end
             % Open new vs. org Comparisons
-            if testCase.openCompare == 1                
+            if testCase.openCompare == 1
                 cd(fullfile(testCase.testDir,   ...
                             'RegressionTests',  ...
                             'RegularWaves'));
                 openfig('figReg.fig');
                 openfig('figRegCIC.fig');
-                openfig('figRegSS.fig');                
+                openfig('figRegSS.fig');
                 cd(fullfile(testCase.testDir,   ...
                             'RegressionTests',  ...
                             'IrregularWaves'));
                 openfig('figIrregCIC.fig');
-                openfig('figIrregSS.fig');                
-            end            
+                openfig('figIrregSS.fig');
+            end
             set(0,'DefaultFigureVisible',testCase.OriginalDefault);
             testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
-                                 testCase.OriginalDefault);            
+                                 testCase.OriginalDefault);
         end
     end
     


### PR DESCRIPTION
This PR expands the regression tests to account for accuracy bugs in BEMIO functions.

Currently the regression tests run the RM3 model using the committed hydroData in ``examples/RM3/hydroData/rm3.h5``.

If a BEMIO function is updated and runs functionally, but is inaccurate, the regression test will still pass because BEMIO is not being re-run. e.g. the tests [here](https://github.com/WEC-Sim/WEC-Sim/pull/1263/checks?check_run_id=27383027089) should have failed because the body cg, cb and volume were written incorrectly. The regression tests passed however because BEMIO is not rerun.

This update will _not_ catch inaccuracies in:
- readCAPYTAINE
- readNEMOH
- readAQWA

but it will catch issues in readWAMIT, radiationIRF, radiationIRFSS, excitationIRF, and writeBEMIOH5