### PR TITLE
readCapytaine - fix reading multiple bodies with <6 dofs

### DIFF
--- a/source/functions/BEMIO/readCAPYTAINE.m
+++ b/source/functions/BEMIO/readCAPYTAINE.m
@@ -476,7 +476,7 @@ for k=1:length(split_body_names)
 end
 
 % set the indices that sort the old dofs/variables into the correct order
-inds = zeros(1,max([6*length(nDofs_per_body),sum(nDofs_per_body)]));
+inds = zeros(1,max([6*length(body_names),sum(nDofs_per_body)]));
 for j=1:length(old_dofs)
     for i=1:length(sorted_dofs)
         if lower(old_dofs(j)) == sorted_dofs(i)

--- a/source/functions/BEMIO/readCAPYTAINE.m
+++ b/source/functions/BEMIO/readCAPYTAINE.m
@@ -476,7 +476,7 @@ for k=1:length(split_body_names)
 end
 
 % set the indices that sort the old dofs/variables into the correct order
-inds = zeros(1,max([6,sum(nDofs_per_body)]));
+inds = zeros(1,max([6*length(nDofs_per_body),sum(nDofs_per_body)]));
 for j=1:length(old_dofs)
     for i=1:length(sorted_dofs)
         if lower(old_dofs(j)) == sorted_dofs(i)

--- a/source/functions/BEMIO/readCAPYTAINE.m
+++ b/source/functions/BEMIO/readCAPYTAINE.m
@@ -476,7 +476,7 @@ for k=1:length(split_body_names)
 end
 
 % set the indices that sort the old dofs/variables into the correct order
-inds = zeros(1,max([6*length(body_names),sum(nDofs_per_body)]));
+inds = zeros(1,length(sorted_dofs));
 for j=1:length(old_dofs)
     for i=1:length(sorted_dofs)
         if lower(old_dofs(j)) == sorted_dofs(i)


### PR DESCRIPTION
This is a bugfix PR to read Capytaine data when there are multiple bodies, each containing <6 DOF of hydrodynamic data

@jniffene see this one-line bugfix for our TEAMER project