### PR TITLE
Resolve issue #1305 - MATLAB deprecation warning in readWAMIT

### DIFF
--- a/source/functions/BEMIO/readWAMIT.m
+++ b/source/functions/BEMIO/readWAMIT.m
@@ -98,7 +98,8 @@ for n = 1:N
         if isempty(strfind(raw{n},'Wave period (sec)'))==0
             T = 2;
             hydro(F).Nf = hydro(F).Nf+1;
-            tmp = textscan(raw{n}(find(raw{n}=='=')+1:end),'%f');
+            rawInd = find(raw{n} == '=');
+            tmp = textscan(raw{n}(rawInd(1)+1:end),'%f');
             hydro(F).T(hydro(F).Nf) = tmp{1};  % Wave periods
             hydro(F).w(hydro(F).Nf) = 2*pi/tmp{1};  % Wave frequencies
         end


### PR DESCRIPTION
This PR resolves #1305. No other BEMIO functions gave this indexing error except readWAMIT.