### PR TITLE
Update Google analytics implementation in docs 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,8 @@ extensions = [
     'sphinxcontrib.matlab',
     'sphinxext.remoteliteralinclude',
     'sphinx_multiversion',
-    'sphinx_rtd_theme'
+    'sphinx_rtd_theme',
+    'sphinxcontrib.googleanalytics',
 ]
 
 # autodoc settings
@@ -161,9 +162,8 @@ html_theme = 'sphinx_rtd_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    'analytics_id': 'UA-88158104-1'
-}
+googleanalytics_id = 'UA-88158104-1'
+googleanalytics_enabled = True
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -17,3 +17,4 @@ dependencies:
     - sphinx-multiversion-scylla
     - sphinxcontrib-matlabdomain
     - sphinxext-remoteliteralinclude
+    - sphinxcontrib-googleanalytics


### PR DESCRIPTION
This PR updates the Google analytics implementation in our docs per the deprecation of ``analytics_id``. See example of failing docs build [here](https://github.com/WEC-Sim/WEC-Sim/actions/runs/11368439659/job/31623533133?pr=1340). Per that deprecation warning, I utilize [sphinxcontrib.googleanalytics](https://pypi.org/project/sphinxcontrib-googleanalytics/) in the build environment