### PR TITLE
MoorDyn variable path support

### DIFF
--- a/source/functions/initializeWecSim.m
+++ b/source/functions/initializeWecSim.m
@@ -136,6 +136,7 @@ if exist('mooring','var') == 1
     simu.numMoorings = length(mooring(1,:));
     for ii = 1:simu.numMoorings
         mooring(ii).checkInputs();
+        mooring(ii).checkPath();
         mooring(ii).setLoc();
         mooring(ii).setNumber(ii);
         if mooring(ii).lookupTableFlag == 1

--- a/source/functions/postProcessWecSim.m
+++ b/source/functions/postProcessWecSim.m
@@ -140,7 +140,7 @@ clear bodiesOutput ptosOutput constraintsOutput ptosimOutput cablesOutput moorin
 % MoorDyn
 for iMoor = 1:simu.numMoorings
     if mooring(iMoor).moorDyn==1
-        output.loadMoorDyn(mooring(iMoor).moorDynLines);
+        output.loadMoorDyn(mooring(iMoor).moorDynLines, mooring(iMoor).moorDynInputFile);
     end
 end; clear iMoor
 

--- a/source/objects/mooringClass.m
+++ b/source/objects/mooringClass.m
@@ -179,13 +179,14 @@ classdef mooringClass<handle
 
         function callMoorDynLib(obj)
             % Initialize MoorDyn Lib (Windows:dll or OSX:dylib)
-            disp('---------------Starting MoorDyn-----------')
             
             if libisloaded('libmoordyn')
                 calllib('libmoordyn', 'MoorDynClose');
                 unloadlibrary libmoordyn;
             end
             
+            disp('---------------Starting MoorDyn-----------')
+
             if ismac
                 loadlibrary('libmoordyn.dylib','MoorDyn.h');
             elseif ispc

--- a/source/objects/mooringClass.m
+++ b/source/objects/mooringClass.m
@@ -83,6 +83,13 @@ classdef mooringClass<handle
             mustBeMember(obj.moorDyn,[0 1])
         end
 
+        function checkPath(obj)
+            % this method checks the moordyn path is correct for reading in outputs
+            assert(isequal(length(strsplit(obj.moorDynInputFile, '.')),2),'MoorDyn input file must only contain a single "." character')
+            assert(isfile(obj.moorDynInputFile), append('The file "', obj.moorDynInputFile, '" does not exist'))
+
+        end
+
         function setInitDisp(obj, relCoord, axisAngleList, addLinDisp)
             % Function to set a mooring's initial displacement
             % 

--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -321,7 +321,7 @@ classdef responseClass<handle
             end
         end
         
-        function obj = loadMoorDyn(obj,linesNum)            
+        function obj = loadMoorDyn(obj,linesNum, InputFile)            
             % This method reads MoorDyn outputs for each instance of the
             % ``mooringClass``
             %            
@@ -329,15 +329,25 @@ classdef responseClass<handle
             % ------------
             %     linesNum : integer
             %         the number of MoorDyn lines
+            %     InputFile : text
+            %         the infile text name 
             %
             
             arguments
                 obj
                 linesNum (1,1) double {mustBeInteger}
+                InputFile (1,:) {mustBeText}
             end
             
-            % load Lines.out
-            filename = './Mooring/Lines.out';
+            % load out files. First find the path and rootname. 
+            InputStrings = strsplit(InputFile, '.');
+
+            if length(InputStrings)> 2
+                error('MoorDyn input file path and root cannot contain "." characters') % this is already checked when mooring class is set up but double checking again
+            end
+            
+            filerootpath = char(InputStrings(1));
+            filename = append(filerootpath,'.out');
             fid = fopen(filename, 'r');
             header = strsplit(fgetl(fid));
             data = dlmread(filename,'',1,0);
@@ -350,7 +360,7 @@ classdef responseClass<handle
             % load Line#.out
             for iline=1:linesNum
                 eval(['obj.moorDyn.Line' num2str(iline) '=struct();']);
-                filename = ['./Mooring/lines_Line' num2str(iline) '.out'];
+                filename = [append(filerootpath,'_Line') num2str(iline) '.out'];
                 try
                     fid = fopen(filename);
                     header = strsplit(strtrim(fgetl(fid)));

--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -321,7 +321,7 @@ classdef responseClass<handle
             end
         end
         
-        function obj = loadMoorDyn(obj,linesNum, InputFile)            
+        function obj = loadMoorDyn(obj,linesNum, inputFile)            
             % This method reads MoorDyn outputs for each instance of the
             % ``mooringClass``
             %            
@@ -329,25 +329,25 @@ classdef responseClass<handle
             % ------------
             %     linesNum : integer
             %         the number of MoorDyn lines
-            %     InputFile : text
+            %     inputFile : text
             %         the infile text name 
             %
             
             arguments
                 obj
                 linesNum (1,1) double {mustBeInteger}
-                InputFile (1,:) {mustBeText}
+                inputFile (1,:) {mustBeText}
             end
             
             % load out files. First find the path and rootname. 
-            InputStrings = strsplit(InputFile, '.');
+            inputStrings = strsplit(inputFile, '.');
 
-            if length(InputStrings)> 2
+            if length(inputStrings)> 2
                 error('MoorDyn input file path and root cannot contain "." characters') % this is already checked when mooring class is set up but double checking again
             end
             
-            filerootpath = char(InputStrings(1));
-            filename = append(filerootpath,'.out');
+            fileRootPath = char(inputStrings(1));
+            filename = append(fileRootPath,'.out');
             fid = fopen(filename, 'r');
             header = strsplit(fgetl(fid));
             data = dlmread(filename,'',1,0);
@@ -360,7 +360,7 @@ classdef responseClass<handle
             % load Line#.out
             for iline=1:linesNum
                 eval(['obj.moorDyn.Line' num2str(iline) '=struct();']);
-                filename = [append(filerootpath,'_Line') num2str(iline) '.out'];
+                filename = [append(fileRootPath,'_Line') num2str(iline) '.out'];
                 try
                     fid = fopen(filename);
                     header = strsplit(strtrim(fgetl(fid)));


### PR DESCRIPTION
This PR fixes some MoorDyn path things to support V2 (input files can have any name or path). Previously there were instances of MoorDyn v1 file naming that was hard coded. Now, the input file name and path is used to derive the output file names and paths. This requires the MoorDyn filename in the wecSimInputFile to only have a single "." character, I added tests accordingly that check this and that the file exists. 

If there are formatting things that need changing here please let me know! I tried to follow how other parts of the code do things as closely as possible. 