### PR TITLE
Fix irregular wave elevation with multiple directions

### DIFF
--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        release: [R2022a, R2022b, R2023a, R2023b]
+        os: [ubuntu-22.04, windows-latest]
+        release: [R2022b, R2023a, R2023b, R2024a, R2024b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-main.yml
+++ b/.github/workflows/run-tests-main.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        release: [R2022a, R2022b, R2023a, R2023b]
+        os: [ubuntu-22.04, windows-latest]
+        release: [R2022b, R2023a, R2023b, R2024a, R2024b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -816,7 +816,7 @@ classdef waveClass<handle
             % Calculate eta
             for i = 1:length(timeseries)
                 tmp  = sqrt(obj.amplitude.*df*obj.spread);
-                tmp1 = tmp.*real(exp(sqrt(-1).*(obj.omega.*timeseries(i) + obj.phase.')));
+                tmp1 = tmp.*real(exp(sqrt(-1).*(obj.omega.*timeseries(i) + obj.phase)));
                 obj.waveAmpTime(i,2) = rampFunction(i)*sum(tmp1,'all');
 
 


### PR DESCRIPTION
This PR fixes the irregular wave elevation function, which was failing for multiple directions. This was causing the [Morison Element applications case to fail](https://github.com/WEC-Sim/WEC-Sim_Applications/actions/runs/12776912600/job/36069012775) - see #1400. The OSWEC case was also erroring because it had multiple wave directions.

@dforbush2 I traced this change back to our PR #1332, but I don't think it was intentional since you created a new function `waves.waveElevFullDir()` for the imported full directional wave elevation. 