### PR TITLE
add keepPool flag to simulationClass

### DIFF
--- a/docs/user/advanced_features.rst
+++ b/docs/user/advanced_features.rst
@@ -166,9 +166,11 @@ which allows parallel capability for :ref:`user-advanced-features-mcr` but adds
 an additional MATLAB dependency to use this feature. Similar to MCR, this 
 feature can be executed in three ways (Options 1~3). 
 
-For PCT runs, the ``*.h5`` hydrodynamic data must be reload, regardless the 
+For PCT runs, the ``*.h5`` hydrodynamic data must be reloaded, regardless the 
 setting for ``simu.reloadH5Data`` in the WEC-Sim input file. 
 
+The option ``simu.keepPool=1`` will retain the parallel pool after simulations have finished to facilitate
+parallel post-processing. If the pool is no longer needed or needs reinitialization, ``simu.keepPool=0`` will close the parallel pool after simulations have completed.     
 
 .. Note::
     The ``userDefinedFunctionsMCR.m`` is not compatible with ``wecSimPCT``. 

--- a/source/objects/simulationClass.m
+++ b/source/objects/simulationClass.m
@@ -37,6 +37,7 @@ classdef simulationClass<handle
         endTime (1,:) {mustBeScalarOrEmpty}             = []                % (`float`) Simulation end time. Default = ``[]``
         explorer (1,:) {mustBeText}                     = 'on'              % (`string`) SimMechanics Explorer 'on' or 'off'. Default = ``'on'``
         gravity (1,1) {mustBePositive}                  = 9.81              % (`float`) Acceleration due to gravity. Default = ``9.81`` m/s
+        keepPool (1,1) logical                          = 1                 % (`logical`) Flag to keep parallel pool open after use of wecSimPCT. Default = ``1``
         mcrMatFile (1,:) {mustBeText}                   = ''                % (`string`) mat file that contain a list of the multiple conditions runs with given conditions. Default = ``[]``  
         mcrExcelFile (1,:) {mustBeText}                 = ''                % (`string`) File name from which to load wave statistics data. Default = ``[]``        
         mode (1,:) {mustBeText}                         = 'normal'          % (`string`) Simulation execution mode, 'normal', 'accelerator', 'rapid-accelerator'. Default = ``'normal'``
@@ -46,7 +47,7 @@ classdef simulationClass<handle
             'option',                                   0,...               % 
             'startTime',                                [], ...             %
             'endTime',                                  [], ...             %
-            'dt',                                       [], ...            % 
+            'dt',                                       [], ...             % 
             'path',                                     'vtk')              % (`structure`) Defines the Paraview visualization. ``option`` (`integer`) Flag for paraview visualization, and writing vtp files, Options: 0 (off) , 1 (on). Default = ``0``. ``startTime`` (`float`) Start time for the vtk file of Paraview. Default = ``0``. ``endTime`` (`float`) End time for the vtk file of Paraview. Default = ``100``.  ``dt`` (`float`) Timestep for Paraview. Default = ``0.1``. ``path`` (`string`) Path of the folder for Paraview vtk files. Default = ``'vtk'``.      
         pressure (1,1) {mustBeInteger}                  = 0                 % (`integer`) Flag to save pressure distribution, Options: 0 (off), 1 (on). Default = ``0``
         rampTime (1,1) {mustBeNumeric}                  = 100               % (`float`) Ramp time for wave forcing. Default = ``100`` s        

--- a/source/wecSimPCT.m
+++ b/source/wecSimPCT.m
@@ -27,11 +27,14 @@ global mcr
 p = parcluster('local');
 totalNumOfWorkers=p.NumWorkers;
 
-% open the parallel pool, recording the time it takes
-tic;
-parpool(p); % open the pool
+% If it isn't already open, open the parallel pool, recording the time it takes
 
-fprintf('Opening the parallel pool took %g seconds.\n', toc)
+if isempty(gcp('nocreate'))
+    tic
+    parpool(p); % open the pool
+
+    fprintf('Opening the parallel pool took %g seconds.\n', toc)
+end
 
 evalc('wecSimInputFile');
 
@@ -114,6 +117,7 @@ parfor imcr=1:length(mcr.cases(:,1))
 end
 
 clear imcr totalNumOfWorkers
-delete(gcp); % close the parallel pool
-
+if simu.keepPool == 0
+    delete(gcp); % close the parallel pool
+end
 


### PR DESCRIPTION
Allows users to run wecSimPCT using an existing parallel pool
Lets users decide whether to close the parallel pool after a successful run of wecSimPCT. By default, the parallel pool stays open, though this can easily be changed by setting `simu.keepPool = 0`.

Closes #1398