### PR TITLE
Updates the Mtalab Versions

### DIFF
--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -41,9 +41,6 @@ jobs:
           sudo apt-get dist-upgrade
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
 
-      - name: Check MATLAB library path
-        run: ldd /opt/hostedtoolcache/MATLAB/2023.2.999/x64/bin/glnxa64/matlab | grep libstdc++
-
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2.3.0
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -34,7 +34,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libstdc++6
+          sudo apt-get install gcc-4.9
+          sudo apt-get upgrade libstdc++6
+          sudo apt-get dist-upgrade
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
 
       - name: Install MATLAB

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -26,13 +26,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          
+
       - name: Check out LFS objects
         run: git lfs checkout
 
       - name: Update libstdc++ (Linux only)
         if: matrix.os == 'ubuntu-latest'
         run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt-get update
           sudo apt-get install -y libstdc++6
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -26,14 +26,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-
+          
       - name: Check out LFS objects
         run: git lfs checkout
 
       - name: Update libstdc++ (Linux only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt-get update
           sudo apt-get install -y libstdc++6
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -46,6 +46,14 @@ jobs:
       - name: Locate libstdc++
         run: find / -name "libstdc++.so.6" 2>/dev/null
 
+      - name: Set LD_LIBRARY_PATH
+        run: echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:\$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+      - name: Verify GLIBCXX version
+        run: |
+          ldd --version
+          strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -38,14 +38,6 @@ jobs:
           sudo apt-get install -y libstdc++6
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
 
-      - name: Check libstdc++ version
-        run: |
-          ldd --version
-          strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
-
-      - name: Locate libstdc++
-        run: find / -name "libstdc++.so.6" 2>/dev/null
-
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -34,6 +34,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update 
           sudo apt install -y g++-11
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
 

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -26,13 +26,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+          
       - name: Check out LFS objects
         run: git lfs checkout
+
+      - name: Update libstdc++ (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libstdc++6
+          strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{ matrix.release }}
           products: Simulink Simscape Simscape_Multibody
+
       - name: Install WEC-Sim, run tests and generate artifacts
         uses: matlab-actions/run-command@v2
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -42,7 +42,6 @@ jobs:
       
           # Check available GLIBCXX versions in the system's libstdc++
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
-      
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2.3.0
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -33,20 +33,15 @@ jobs:
       - name: Update libstdc++  and LD_LIBRARY_PATH  (Linux only)
         if: matrix.os == 'ubuntu-latest'
         run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test 
           sudo apt-get update
-          sudo apt-get install -y build-essential gcc-11 g++-11
-          # Check and replace libstdc++ if necessary for all installed MATLAB versions
-          for version in /opt/hostedtoolcache/MATLAB/*/x64/sys/os/glnxa64; do
-            if [ -f "$version/libstdc++.so.6" ]; then
-              echo "Replacing libstdc++.so.6 for MATLAB version $version"
-              sudo mv $version/libstdc++.so.6 $version/libstdc++.so.6.bak
-              sudo ln -s /usr/lib/x86_64-linux-gnu/libstdc++.so.6 $version/libstdc++.so.6
-            fi
-          done
+          sudo apt-get install gcc-4.9
+          sudo apt-get upgrade libstdc++6
 
-          # Update LD_LIBRARY_PATH
-          echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:\$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          sudo apt-get dist-upgrade
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+
+          LD_LIBRARY_PATH=/usr/local/lib64:$LD_LIBRARY_PATH 
 
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2.3.0

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -43,10 +43,6 @@ jobs:
           # Check available GLIBCXX versions in the system's libstdc++
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
       
-      - name: Check libstdc++ version
-        run: |
-            dpkg-query -l | grep libstdc++
-
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2.3.0
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -40,15 +40,10 @@ jobs:
 
           sudo apt-get dist-upgrade
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+          echo $LD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 
-          ldd /lib/x86_64-linux-gnu/libgallium-24.2.8-1ubuntu1~24.04.1.so
 
-          locate libstdc++.so.6 
-
-          find /usr -name libstdc++.so.6 2>/dev/null
-          gcc --version
-
-          export LD_LIBRARY_PATH=/opt/new-libstdc++-path:$LD_LIBRARY_PATH
 
 
       - name: Install MATLAB

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -46,14 +46,6 @@ jobs:
       - name: Locate libstdc++
         run: find / -name "libstdc++.so.6" 2>/dev/null
 
-      - name: Set LD_LIBRARY_PATH
-        run: echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:\$LD_LIBRARY_PATH" >> $GITHUB_ENV
-
-      - name: Verify GLIBCXX version
-        run: |
-          ldd --version
-          strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
-
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -41,7 +41,15 @@ jobs:
           sudo apt-get dist-upgrade
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
 
-          LD_LIBRARY_PATH=/usr/local/lib64:$LD_LIBRARY_PATH 
+          ldd /lib/x86_64-linux-gnu/libgallium-24.2.8-1ubuntu1~24.04.1.so
+
+          locate libstdc++.so.6 
+
+          find /usr -name libstdc++.so.6 2>/dev/null
+          gcc --version
+
+          export LD_LIBRARY_PATH=/opt/new-libstdc++-path:$LD_LIBRARY_PATH
+
 
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2.3.0

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -30,21 +30,9 @@ jobs:
       - name: Check out LFS objects
         run: git lfs checkout
 
-      - name: Update libstdc++  and LD_LIBRARY_PATH  (Linux only)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Check libstdc++ version
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test 
-          sudo apt-get update
-          sudo apt-get install gcc-4.9
-          sudo apt-get upgrade libstdc++6
-
-          sudo apt-get dist-upgrade
-          strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
-          echo $LD_LIBRARY_PATH
-          export LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
-
-
-
+            dpkg-query -l | grep libstdc++
 
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2.3.0

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -30,14 +30,19 @@ jobs:
       - name: Check out LFS objects
         run: git lfs checkout
 
-      - name: Update libstdc++  and LD_LIBRARY_PATH  (Linux only)
+      - name: Update libstdc++ and LD_LIBRARY_PATH (Linux only)
         if: matrix.os == 'ubuntu-latest'
         run: |
+          # Add the repository with updated toolchain
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update 
-          sudo apt install -y g++-11
+          sudo apt-get update
+      
+          # Install g++-11 (which provides the newer libstdc++)
+          sudo apt-get install -y g++-11
+      
+          # Check available GLIBCXX versions in the system's libstdc++
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
-
+      
       - name: Check libstdc++ version
         run: |
             dpkg-query -l | grep libstdc++

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -30,10 +30,6 @@ jobs:
       - name: Check out LFS objects
         run: git lfs checkout
 
-      - name: Check libstdc++ version
-        run: |
-            dpkg-query -l | grep libstdc++
-
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2.3.0
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -41,14 +41,17 @@ jobs:
           sudo apt-get dist-upgrade
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
 
+      - name: Check MATLAB library path
+        run: ldd /opt/hostedtoolcache/MATLAB/2023.2.999/x64/bin/glnxa64/matlab | grep libstdc++
+
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v2.3.0
         with:
           release: ${{ matrix.release }}
           products: Simulink Simscape Simscape_Multibody
 
       - name: Install WEC-Sim, run tests and generate artifacts
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v2.1.1
         with:
           command: |
             addpath(genpath('source')),

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -38,6 +38,14 @@ jobs:
           sudo apt-get install -y libstdc++6
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
 
+      - name: Check libstdc++ version
+        run: |
+          ldd --version
+          strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+
+      - name: Locate libstdc++
+        run: find / -name "libstdc++.so.6" 2>/dev/null
+
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -46,7 +46,7 @@ jobs:
           products: Simulink Simscape Simscape_Multibody
 
       - name: Install WEC-Sim, run tests and generate artifacts
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v2.1.1
         with:
           command: |
             addpath(genpath('source')),

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -30,15 +30,22 @@ jobs:
       - name: Check out LFS objects
         run: git lfs checkout
 
-      - name: Update libstdc++ (Linux only)
+      - name: Update libstdc++  and LD_LIBRARY_PATH  (Linux only)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install gcc-4.9
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get install -y build-essential gcc-11 g++-11
+          # Check and replace libstdc++ if necessary for all installed MATLAB versions
+          for version in /opt/hostedtoolcache/MATLAB/*/x64/sys/os/glnxa64; do
+            if [ -f "$version/libstdc++.so.6" ]; then
+              echo "Replacing libstdc++.so.6 for MATLAB version $version"
+              sudo mv $version/libstdc++.so.6 $version/libstdc++.so.6.bak
+              sudo ln -s /usr/lib/x86_64-linux-gnu/libstdc++.so.6 $version/libstdc++.so.6
+            fi
+          done
 
-          sudo apt-get upgrade libstdc++6
-          sudo apt-get dist-upgrade
+          # Update LD_LIBRARY_PATH
+          echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:\$LD_LIBRARY_PATH" >> $GITHUB_ENV
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
 
       - name: Install MATLAB

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        release: [R2022a, R2022b, R2023a, R2023b]
+        release: [R2023a, R2023b, R2024a, R2024b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install gcc-4.9
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+
           sudo apt-get upgrade libstdc++6
           sudo apt-get dist-upgrade
           strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
@@ -46,7 +48,7 @@ jobs:
           products: Simulink Simscape Simscape_Multibody
 
       - name: Install WEC-Sim, run tests and generate artifacts
-        uses: matlab-actions/run-command@v2.1.1
+        uses: matlab-actions/run-command@v2
         with:
           command: |
             addpath(genpath('source')),

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -30,6 +30,17 @@ jobs:
       - name: Check out LFS objects
         run: git lfs checkout
 
+      - name: Update libstdc++  and LD_LIBRARY_PATH  (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt install -y g++-11
+          strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+
+      - name: Check libstdc++ version
+        run: |
+            dpkg-query -l | grep libstdc++
+
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2.3.0
         with:

--- a/.github/workflows/run-tests-main.yml
+++ b/.github/workflows/run-tests-main.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        release: [R2022a, R2022b, R2023a, R2023b]
+        release: [R2023a, R2023b, R2024a, R2024b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository


### PR DESCRIPTION
There is a compatibility issue between the ubuntu-latest (ubuntu-20.04) and Matlab 2022a and 2022b. 
This PR excludes these two Matlab Versions from the tests and includes 2024a and 2024b. 