### PR TITLE
Updates the Ubuntu and Matlab versions

### DIFF
--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-latest]
-        release: [R2022b, R2023a, R2023b, 2024a, 2024b]
+        release: [R2022b, R2023a, R2023b, R2024a, R2024b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        release: [R2022a, R2022b, R2023a, R2023b]
+        os: [ubuntu-22.04, windows-latest]
+        release: [R2022b, R2023a, R2023b, 2024a, 2024b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-main.yml
+++ b/.github/workflows/run-tests-main.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-latest]
-        release: [R2022b, R2023a, R2023b, 2024a, 2024b]
+        release: [R2022b, R2023a, R2023b, R2024a, R2024b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-main.yml
+++ b/.github/workflows/run-tests-main.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        release: [R2022a, R2022b, R2023a, R2023b]
+        os: [ubuntu-22.04, windows-latest]
+        release: [R2022b, R2023a, R2023b, 2024a, 2024b]
     name: ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository


### PR DESCRIPTION
Updates the Matlab and the Ubuntu versions in the workflow.

Limits the tests to ubuntu-22.04 rather than ubuntu-latest (ubuntu-24.04). Only Matlab 2024x is compatible with ubuntu-24.04.

Noting that the Ubuntu 20.04 runner image will be fully unsupported by github on April 1, 2025