### PR TITLE
build Body from hydro structure directly

### DIFF
--- a/docs/user/advanced_features.rst
+++ b/docs/user/advanced_features.rst
@@ -962,10 +962,14 @@ Alternatively, users may input a ``hydroData`` structure directly to the body co
 pre-processing steps that require writing the H5 file with BEMIO and then reloading it in the bodyClass.
 This workflow may save users time in computationally expensive scenarios.
 
-This altnerate workflow is used by defining a body as: :code:`body(i) = bodyClass(hydroData)`. 
+This alternate workflow is used by defining a body as: :code:`body(i) = bodyClass(hydroData)`. 
 Users should take care to ensure that the ``hydroData`` structure passed is identical in form to that 
-which ``initializeWecSim`` obtains by calling
+which ``initializeWecSim`` obtains by calling:
+
 :code:`hydroData = readBEMIOH5('pathToH5File', body.number, body.meanDrift);`
+
+The function :code:`rebuildHydroStruct()` may be used to convert the BEMIO :code:`hydro` structure
+into the bodyClass :code:`hydroData` format.
 
 
 .. _user-advanced-features-pto:

--- a/docs/user/advanced_features.rst
+++ b/docs/user/advanced_features.rst
@@ -955,6 +955,18 @@ Variable Hydrodynamics
 
 .. include:: /_include/variable_hydro.rst
 
+Body Initialization
+^^^^^^^^^^^^^^^^^^^
+The bodyClass is typically defined by inputting one or more paths to H5 files in the body constructor. 
+Alternatively, users may input a ``hydroData`` structure directly to the body constructor to bypass the 
+pre-processing steps that require writing the H5 file with BEMIO and then reloading it in the bodyClass.
+This workflow may save users time in computationally expensive scenarios.
+
+This altnerate workflow is used by defining a body as: :code:`body(i) = bodyClass(hydroData)`. 
+Users should take care to ensure that the ``hydroData`` structure passed is identical in form to that 
+which ``initializeWecSim`` obtains by calling
+:code:`hydroData = readBEMIOH5('pathToH5File', body.number, body.meanDrift);`
+
 
 .. _user-advanced-features-pto:
 

--- a/source/functions/BEMIO/readH5ToStruct.m
+++ b/source/functions/BEMIO/readH5ToStruct.m
@@ -84,10 +84,12 @@ for i = 1:hydro.Nb
     try hydro.ss_conv(dofStart:dofEnd,:) = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/radiation_damping/state_space/conv'])); end
 
     % Read GBM coefficients if available
-    try hydro.gbm(dofStart:dofEnd,:,1) = h5read(filename,[h5BodyName '/properties/mass']); end
-    try hydro.gbm(dofStart:dofEnd,:,2) = h5read(filename,[h5BodyName '/properties/damping']); end
-    try hydro.gbm(dofStart:dofEnd,:,3) = h5read(filename,[h5BodyName '/properties/stiffness']); end
-    try hydro.gbm(dofStart:dofEnd,:,4) = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/linear_restoring_stiffness'])); end
+    try 
+        hydro.gbm(dofStart:dofEnd,:,1) = h5read(filename,[h5BodyName '/properties/mass']);
+        hydro.gbm(dofStart:dofEnd,:,2) = h5read(filename,[h5BodyName '/properties/damping']);
+        hydro.gbm(dofStart:dofEnd,:,3) = h5read(filename,[h5BodyName '/properties/stiffness']);
+        hydro.gbm(dofStart:dofEnd,:,4) = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/linear_restoring_stiffness']));
+    end
 
     % Read mean drift variables if available
     try hydro.md_mc(dofStart:dofEnd,:,:) = reverseDimensionOrder(h5read(filename, [h5BodyName '/hydro_coeffs/mean_drift/momentum_conservation/val'])); end

--- a/source/functions/BEMIO/rebuildHydroStruct.m
+++ b/source/functions/BEMIO/rebuildHydroStruct.m
@@ -8,6 +8,15 @@ function [hydroData] = rebuildHydroStruct(hydro, iBod, meanDrift)
 %         BEMIO-type structure of hydrodynamic data that would be written
 %         to an H5 file.
 % 
+%     iBod : float
+%         Body number that hydroData will correspond to. For multiple
+%         bodies in the same hydro structure, use multiple calls to the
+%         function while iterating through all relevant body numbers.
+% 
+%     meanDrift : float
+%         Flag to determine which mean drift coefficients are used. Should
+%         be identical to body.meanDrift
+% 
 % Returns
 % -------
 %     hydroData : struct

--- a/source/functions/BEMIO/rebuildHydroStruct.m
+++ b/source/functions/BEMIO/rebuildHydroStruct.m
@@ -58,7 +58,7 @@ hydroData.properties.dofEnd = dofEnd;
 
 % Read hydrostatic stiffness
 if isfield(hydro,'gbm')
-    hydroData.hydro_coeffs.linear_restoring_stiffness = hydro.gbm(dofStart:dofEnd, dofStart:dofEnd, 4);
+    hydroData.hydro_coeffs.linear_restoring_stiffness = hydro.gbm(dofStart:dofEnd, :, 4);
 else
     hydroData.hydro_coeffs.linear_restoring_stiffness = hydro.Khs(:, :, iBod);
 end
@@ -96,7 +96,7 @@ hydroData.hydro_coeffs.added_mass.inf_freq = hydro.Ainf(dofStart:dofEnd, :);
 hydroData.hydro_coeffs.radiation_damping = struct();
 hydroData.hydro_coeffs.radiation_damping.all = hydro.B(dofStart:dofEnd, :, :);
 try hydroData.hydro_coeffs.radiation_damping.impulse_response_fun.K = hydro.ra_K(dofStart:dofEnd, :, :); end
-try hydroData.hydro_coeffs.radiation_damping.impulse_response_fun.t = hydro.ra_t; end
+try hydroData.hydro_coeffs.radiation_damping.impulse_response_fun.t = hydro.ra_t'; end
 
 % Read radiation damping state space coefficients
 try hydroData.hydro_coeffs.radiation_damping.state_space.it = hydro.ss_O(dofStart:dofEnd, :); end
@@ -108,8 +108,8 @@ try hydroData.hydro_coeffs.radiation_damping.state_space.D.all = hydro.ss_D(dofS
 % Read GBM parameters if available
 try 
     hydroData.gbm.mass = hydro.gbm(dofStart+6:dofEnd, dofStart+6:dofEnd, 1);
-    hydroData.gbm.stiffness = hydro.gbm(dofStart+6:dofEnd, dofStart+6:dofEnd, 2);
-    hydroData.gbm.damping = hydro.gbm(dofStart+6:dofEnd, dofStart+6:dofEnd, 3);
+    hydroData.gbm.damping = hydro.gbm(dofStart+6:dofEnd, dofStart+6:dofEnd, 2);
+    hydroData.gbm.stiffness = hydro.gbm(dofStart+6:dofEnd, dofStart+6:dofEnd, 3);
 end
 
 % Read mean drift coefficients if available

--- a/source/functions/BEMIO/rebuildHydroStruct.m
+++ b/source/functions/BEMIO/rebuildHydroStruct.m
@@ -1,55 +1,125 @@
-function [newhydro] = rebuildHydroStruct(hydro)
-% converts a BEMIO format hydro stucture to the Body Class format hydro structure
+function [hydroData] = rebuildHydroStruct(hydro, iBod, meanDrift)
+% converts a BEMIO format hydro stucture to the Body Class format hydroData structure
+% Author: @degoeden
+% 
+% Parameters
+% ----------
+%     hydro : struct
+%         BEMIO-type structure of hydrodynamic data that would be written
+%         to an H5 file.
+% 
+% Returns
+% -------
+%     hydroData : struct
+%         Struct of hydroData used by the bodyClass. Different format than
+%         the BEMIO hydro struct
+% 
 
-newhydro = struct;
-newhydro.simulation_parameters = struct();
-newhydro.properties = struct();
-newhydro.hydro_coeffs = struct();
+% Set-up format
+hydroData = struct;
+hydroData.simulation_parameters = struct();
+hydroData.properties = struct();
+hydroData.hydro_coeffs = struct();
 
-newhydro.simulation_parameters.scaled = 0;
-newhydro.simulation_parameters.direction = hydro.theta;
-newhydro.simulation_parameters.waterDepth = hydro.h;
-newhydro.simulation_parameters.w = hydro.w;
-newhydro.simulation_parameters.T = hydro.T;
+% Read body-independent wave parameters
+hydroData.simulation_parameters.scaled = 0;
+hydroData.simulation_parameters.direction = hydro.theta;
+hydroData.simulation_parameters.waterDepth = hydro.h;
+hydroData.simulation_parameters.w = hydro.w;
+hydroData.simulation_parameters.T = hydro.T;
 
+% Read body properties
 if ischar(hydro.body)
-    newhydro.properties.name = hydro.body;
+    hydroData.properties.name = hydro.body;
 else
-    newhydro.properties.name = hydro.body{1};
+    hydroData.properties.name = hydro.body{iBod};
 end
 
-newhydro.properties.number = 1;
-newhydro.properties.centerGravity = hydro.cg;
-newhydro.properties.centerBuoyancy = hydro.cb;
-newhydro.properties.volume = hydro.Vo;
-newhydro.properties.dof = hydro.dof;
-newhydro.properties.dofStart = 1;
-newhydro.properties.dofEnd = hydro.dof;
+hydroData.properties.number = iBod;
+hydroData.properties.centerGravity = hydro.cg(:,iBod)';
+hydroData.properties.centerBuoyancy = hydro.cb(:,iBod)';
+hydroData.properties.volume = hydro.Vo(iBod);
 
-newhydro.hydro_coeffs.linear_restoring_stiffness = hydro.Khs;
-newhydro.hydro_coeffs.excitation = struct();
-newhydro.hydro_coeffs.excitation.re = hydro.ex_re;
-newhydro.hydro_coeffs.excitation.im = hydro.ex_im;
-newhydro.hydro_coeffs.excitation.impulse_response_fun = struct();
-newhydro.hydro_coeffs.excitation.impulse_response_fun.f = hydro.ex_K;
-newhydro.hydro_coeffs.excitation.impulse_response_fun.t = hydro.ex_t';
-newhydro.hydro_coeffs.added_mass = struct();
-newhydro.hydro_coeffs.added_mass.all = hydro.A;
-newhydro.hydro_coeffs.added_mass.inf_freq = hydro.Ainf;
-newhydro.hydro_coeffs.radiation_damping = struct();
-newhydro.hydro_coeffs.radiation_damping.all = hydro.B;
-newhydro.hydro_coeffs.radiation_damping.impulse_response_fun = struct();
-newhydro.hydro_coeffs.radiation_damping.impulse_response_fun.K = hydro.ra_K;
-newhydro.hydro_coeffs.radiation_damping.impulse_response_fun.t = hydro.ra_t';
-newhydro.hydro_coeffs.radiation_damping.state_space = struct();
-newhydro.hydro_coeffs.radiation_damping.state_space.it = hydro.ss_O;
-newhydro.hydro_coeffs.radiation_damping.state_space.A = struct();
-newhydro.hydro_coeffs.radiation_damping.state_space.A.all = hydro.ss_A;
-newhydro.hydro_coeffs.radiation_damping.state_space.B = struct();
-newhydro.hydro_coeffs.radiation_damping.state_space.B.all = hydro.ss_B;
-newhydro.hydro_coeffs.radiation_damping.state_space.C = struct();
-newhydro.hydro_coeffs.radiation_damping.state_space.C.all = hydro.ss_C;
-newhydro.hydro_coeffs.radiation_damping.state_space.D = struct();
-newhydro.hydro_coeffs.radiation_damping.state_space.D.all = hydro.ss_D;
-newhydro.hydro_coeffs.mean_drift = zeros(hydro.dof,1,hydro.Nf);
+% Read DOFs
+if iBod > 1
+    dofStart = sum(hydro.dof(1:iBod-1)) + 1;
+    dofEnd = hydroData.properties.dofStart - 1 + hydroData.properties.dof;
+else
+    dofStart = 1;
+    dofEnd = hydroData.properties.dof;
+end
+hydroData.properties.dof = hydro.dof(iBod);
+hydroData.properties.dofStart = dofStart;
+hydroData.properties.dofEnd = dofEnd;
+
+% Read hydrostatic stiffness
+if isfield(hydro,'gbm')
+    hydroData.hydro_coeffs.linear_restoring_stiffness = hydro.gbm(dofStart:dofEnd, dofStart:dofEnd, 4);
+else
+    hydroData.hydro_coeffs.linear_restoring_stiffness = hydro.Khs(:, :, iBod);
+end
+
+% Read excitation coefficients and IRF
+hydroData.hydro_coeffs.excitation = struct();
+hydroData.hydro_coeffs.excitation.re = hydro.ex_re(dofStart:dofEnd, :, :);
+hydroData.hydro_coeffs.excitation.im = hydro.ex_im(dofStart:dofEnd, :, :);
+try hydroData.hydro_coeffs.excitation.impulse_response_fun.f = hydro.ex_K(dofStart:dofEnd, :, :); end
+try hydroData.hydro_coeffs.excitation.impulse_response_fun.t = hydro.ex_t; end
+
+% Read second order excitation forces data (QTFs)
+try
+    for dof = 1 : hydroData.properties.dof
+        hydroData.hydro_coeffs.excitation.QTFs.Sum(dof).PER_i = hydro.QTFs(iBod).Sum(dof).PER_i;
+        hydroData.hydro_coeffs.excitation.QTFs.Sum(dof).BETA_i = hydro.QTFs(iBod).Sum(dof).BETA_i;
+        hydroData.hydro_coeffs.excitation.QTFs.Sum(dof).BETA_j = hydro.QTFs(iBod).Sum(dof).BETA_j;
+        hydroData.hydro_coeffs.excitation.QTFs.Sum(dof).PHS_F_ij = hydro.QTFs(iBod).Sum(dof).PHS_F_ij;
+        hydroData.hydro_coeffs.excitation.QTFs.Sum(dof).Re_F_ij = hydro.QTFs(iBod).Sum(dof).Re_F_ij;
+        hydroData.hydro_coeffs.excitation.QTFs.Sum(dof).Im_F_ij = hydro.QTFs(iBod).Sum(dof).Im_F_ij;
+        hydroData.hydro_coeffs.excitation.QTFs.Diff(dof).PER_i = hydro.QTFs(iBod).Diff(dof).PER_i;
+        hydroData.hydro_coeffs.excitation.QTFs.Diff(dof).BETA_i = hydro.QTFs(iBod).Diff(dof).BETA_i;
+        hydroData.hydro_coeffs.excitation.QTFs.Diff(dof).BETA_j = hydro.QTFs(iBod).Diff(dof).BETA_j;
+        hydroData.hydro_coeffs.excitation.QTFs.Diff(dof).PHS_F_ij = hydro.QTFs(iBod).Diff(dof).PHS_F_ij;
+        hydroData.hydro_coeffs.excitation.QTFs.Diff(dof).Re_F_ij = hydro.QTFs(iBod).Diff(dof).Re_F_ij;
+        hydroData.hydro_coeffs.excitation.QTFs.Diff(dof).Im_F_ij = hydro.QTFs(iBod).Diff(dof).Im_F_ij;
+    end
+end
+
+% Read added mass coefficients
+hydroData.hydro_coeffs.added_mass.all = hydro.A(dofStart:dofEnd, :, :);
+hydroData.hydro_coeffs.added_mass.inf_freq = hydro.Ainf(dofStart:dofEnd, :);
+
+% Read radiation damping coefficients and IRF
+hydroData.hydro_coeffs.radiation_damping = struct();
+hydroData.hydro_coeffs.radiation_damping.all = hydro.B(dofStart:dofEnd, :, :);
+try hydroData.hydro_coeffs.radiation_damping.impulse_response_fun.K = hydro.ra_K(dofStart:dofEnd, :, :); end
+try hydroData.hydro_coeffs.radiation_damping.impulse_response_fun.t = hydro.ra_t; end
+
+% Read radiation damping state space coefficients
+try hydroData.hydro_coeffs.radiation_damping.state_space.it = hydro.ss_O(dofStart:dofEnd, :); end
+try hydroData.hydro_coeffs.radiation_damping.state_space.A.all = hydro.ss_A(dofStart:dofEnd, :, :, :); end
+try hydroData.hydro_coeffs.radiation_damping.state_space.B.all = hydro.ss_B(dofStart:dofEnd, :, :, :); end
+try hydroData.hydro_coeffs.radiation_damping.state_space.C.all = hydro.ss_C(dofStart:dofEnd, :, :, :); end
+try hydroData.hydro_coeffs.radiation_damping.state_space.D.all = hydro.ss_D(dofStart:dofEnd, :); end
+
+% Read GBM parameters if available
+try 
+    hydroData.gbm.mass = hydro.gbm(dofStart+6:dofEnd, dofStart+6:dofEnd, 1);
+    hydroData.gbm.stiffness = hydro.gbm(dofStart+6:dofEnd, dofStart+6:dofEnd, 2);
+    hydroData.gbm.damping = hydro.gbm(dofStart+6:dofEnd, dofStart+6:dofEnd, 3);
+end
+
+% Read mean drift coefficients if available
+switch meanDrift
+    case 0
+        hydroData.hydro_coeffs.mean_drift = 0.*hydroData.hydro_coeffs.excitation.re;
+    case 1
+        hydroData.hydro_coeffs.mean_drift = hydro.md_cs(dofStart:dofEnd, :, :);
+    case 2
+        hydroData.hydro_coeffs.mean_drift = hydro.md_mc(dofStart:dofEnd, :, :);
+    case 3
+        hydroData.hydro_coeffs.mean_drift = hydro.md_pi(dofStart:dofEnd, :, :);
+    otherwise
+        error(['Wrong flag for mean drift force in body(' num2str(iBod) ').']);
+end
+
 end

--- a/source/functions/BEMIO/rebuildHydroStruct.m
+++ b/source/functions/BEMIO/rebuildHydroStruct.m
@@ -24,7 +24,11 @@ hydroData.hydro_coeffs = struct();
 % Read body-independent wave parameters
 hydroData.simulation_parameters.scaled = 0;
 hydroData.simulation_parameters.direction = hydro.theta;
-hydroData.simulation_parameters.waterDepth = hydro.h;
+if isequal(hydro.h,Inf)
+    hydroData.simulation_parameters.waterDepth = 'infinite';
+else
+    hydroData.simulation_parameters.waterDepth = hydro.h;
+end
 hydroData.simulation_parameters.w = hydro.w;
 hydroData.simulation_parameters.T = hydro.T;
 
@@ -41,14 +45,14 @@ hydroData.properties.centerBuoyancy = hydro.cb(:,iBod)';
 hydroData.properties.volume = hydro.Vo(iBod);
 
 % Read DOFs
+hydroData.properties.dof = hydro.dof(iBod);
 if iBod > 1
     dofStart = sum(hydro.dof(1:iBod-1)) + 1;
-    dofEnd = hydroData.properties.dofStart - 1 + hydroData.properties.dof;
+    dofEnd = dofStart - 1 + hydroData.properties.dof;
 else
     dofStart = 1;
     dofEnd = hydroData.properties.dof;
 end
-hydroData.properties.dof = hydro.dof(iBod);
 hydroData.properties.dofStart = dofStart;
 hydroData.properties.dofEnd = dofEnd;
 
@@ -64,7 +68,7 @@ hydroData.hydro_coeffs.excitation = struct();
 hydroData.hydro_coeffs.excitation.re = hydro.ex_re(dofStart:dofEnd, :, :);
 hydroData.hydro_coeffs.excitation.im = hydro.ex_im(dofStart:dofEnd, :, :);
 try hydroData.hydro_coeffs.excitation.impulse_response_fun.f = hydro.ex_K(dofStart:dofEnd, :, :); end
-try hydroData.hydro_coeffs.excitation.impulse_response_fun.t = hydro.ex_t; end
+try hydroData.hydro_coeffs.excitation.impulse_response_fun.t = hydro.ex_t'; end
 
 % Read second order excitation forces data (QTFs)
 try

--- a/source/functions/initializeWecSim.m
+++ b/source/functions/initializeWecSim.m
@@ -203,6 +203,7 @@ for ii = 1:simu.numHydroBodies
             for iH = 1:length(body(ii).hydroStruct)
                 body(ii).loadHydroData(body(ii).hydroStruct(iH), iH);
             end
+            body(ii).hydroStruct = {}; % clear the temporary hydroStruct variable to avoid duplicating the info in body.hydroData
         end
     end
 end; clear ii iH

--- a/source/functions/initializeWecSim.m
+++ b/source/functions/initializeWecSim.m
@@ -199,7 +199,7 @@ for ii = 1:simu.numHydroBodies
             end
             clear tmp_hydroData
         else
-        % Load hydro data directly from structure
+            % Load hydro data directly from structure
             for iH = 1:length(body(ii).hydroStruct)
                 body(ii).loadHydroData(body(ii).hydroStruct(iH), iH);
             end

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -106,13 +106,13 @@ classdef bodyClass<handle
     end
 
     methods (Access = 'public') % modify object = T; output = F
-        function obj = bodyClass(hydroData)
+        function obj = bodyClass(hydroInput)
             % This method initializes the ``bodyClass`` and creates a
             % ``body`` object.
             %
             % Parameters
             % ------------
-            %     hydroData : string or struct
+            %     hydroInput : string or struct
             %         String specifying the location of the body h5 file
             %         or a struct containing the hydrodynamic data.
             %
@@ -121,26 +121,26 @@ classdef bodyClass<handle
             %     body : obj
             %         bodyClass object
             %
-            if exist('hydroData','var')
-                if isstring(hydroData) || ischar(hydroData)
-                    obj.h5File{1} = hydroData;
+            if exist('hydroInput','var')
+                if isstring(hydroInput) || ischar(hydroInput)
+                    obj.h5File{1} = hydroInput;
                     obj.useH5 = true;
-                elseif iscell(hydroData)
-                    obj.h5File = hydroData;
+                elseif iscell(hydroInput)
+                    obj.h5File = hydroInput;
                     obj.useH5 = true;
-                elseif isstruct(hydroData)
+                elseif isstruct(hydroInput)
                     % Quick check on hydro Data structure, currently not very robust,
                     % but confirms the user isn't trying to use the BEMIO hydro struct
                     % instead of the one needed for the bodyClass.
                     requiredFields = {'properties', 'simulation_parameters', 'hydro_coeffs'};
                     for i = 1:length(requiredFields)
-                        if ~isfield(hydroData, requiredFields{i})
-                            error('The hydroData structure must contain the field "%s".', requiredFields{i});
+                        if ~isfield(hydroInput, requiredFields{i})
+                            error('The hydroInput structure must contain the field "%s".', requiredFields{i});
                         end
                     end
 
                     % set hydro structure, and indicate that we will not be using an h5 file
-                    obj.hydroStruct = hydroData;
+                    obj.hydroStruct = hydroInput;
                     obj.useH5 = false;
                 else
                     error('body.h5File must be a string, cell array of strings, or struct');

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -37,7 +37,6 @@ classdef bodyClass<handle
         gbmDOF (1,:) {mustBeScalarOrEmpty}          = []                    % (`integer`) Number of degree of freedoms (DOFs) for generalized body mode (GBM). Default = ``[]``.
         geometryFile (1,:) {mustBeText}             = 'NONE'                % (`string`) Path to the body geometry ``.stl`` file.
         h5File (1,:) {mustBeA(h5File,{'char','string','cell'})} = ''        % (`char array, string, cell array of char arrays, or cell array or strings`) hdf5 file containing the hydrodynamic data
-        hydroStruct                                 = struct()              % (`structure`) A structure array that defines the hydrodynamic data from BEM or user defined.
         useH5(1,1)                                  = true                  % (`boolean`) Flag to use h5 file for hydrodynamic data.
         hydroStiffness (6,6,:) {mustBeNumeric}      = zeros(6)              % (`6x6 float matrix`) Linear hydrostatic stiffness matrix. If the variable is nonzero, the matrix will override the h5 file values. Create a 3D matrix (6x6xn) for variable hydrodynamics. Default = ``zeros(6)``.
         inertia (1,:) {mustBeNumeric}               = []                    % (`1x3 float vector`) Rotational inertia or mass moment of inertia [kg*m^{2}]. Defined by the user in the following format [Ixx Iyy Izz]. Default = ``[]``.
@@ -81,9 +80,10 @@ classdef bodyClass<handle
     end
 
     properties (SetAccess = 'private', GetAccess = 'public')% h5 file
-        dofEnd              = []                            % (`integer`) Index the DOF ends for (``body.number``). For WEC bodies this is given in the h5 file, but if not defined in the h5 file, Default = ``(body.number-1)*6+6``.
-        dofStart            = []                            % (`integer`) Index the DOF starts for (``body.number``). For WEC bodies this is given in the h5 file, but if not defined in the h5 file, Default = ``(body.number-1)*6+1``.
-        hydroData           = struct()                      % (`structure`) A structure array that defines the hydrodynamic data from BEM or user defined.
+        dofEnd              = []                               % (`integer`) Index the DOF ends for (``body.number``). For WEC bodies this is given in the h5 file, but if not defined in the h5 file, Default = ``(body.number-1)*6+6``.
+        dofStart            = []                               % (`integer`) Index the DOF starts for (``body.number``). For WEC bodies this is given in the h5 file, but if not defined in the h5 file, Default = ``(body.number-1)*6+1``.
+        hydroData           = struct()                         % (`structure`) A structure array that defines the hydrodynamic data from BEM or user defined.
+        hydroStruct         = struct()                         % (`structure`) A temporary structure array that contains hydroData when it is directly used in the bodyClass constructor.
     end
 
     properties (SetAccess = 'private', GetAccess = 'public')% internal
@@ -217,7 +217,7 @@ classdef bodyClass<handle
                     end
                 end
             end
-            
+
             if ~strcmp(obj.mass,'equilibrium') && ~isscalar(obj.mass)
                 error('Body mass must be defined as a scalar or set to `equilibrium`')
             end

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -37,8 +37,8 @@ classdef bodyClass<handle
         gbmDOF (1,:) {mustBeScalarOrEmpty}          = []                    % (`integer`) Number of degree of freedoms (DOFs) for generalized body mode (GBM). Default = ``[]``.
         geometryFile (1,:) {mustBeText}             = 'NONE'                % (`string`) Path to the body geometry ``.stl`` file.
         h5File (1,:) {mustBeA(h5File,{'char','string','cell'})} = ''        % (`char array, string, cell array of char arrays, or cell array or strings`) hdf5 file containing the hydrodynamic data
-        useH5(1,1)                                  = true                  % (`boolean`) Flag to use h5 file for hydrodynamic data.
         hydroStiffness (6,6,:) {mustBeNumeric}      = zeros(6)              % (`6x6 float matrix`) Linear hydrostatic stiffness matrix. If the variable is nonzero, the matrix will override the h5 file values. Create a 3D matrix (6x6xn) for variable hydrodynamics. Default = ``zeros(6)``.
+        hydroStruct                                 = struct()              % (`structure`) A temporary structure array that contains hydroData when it is directly used in the bodyClass constructor.
         inertia (1,:) {mustBeNumeric}               = []                    % (`1x3 float vector`) Rotational inertia or mass moment of inertia [kg*m^{2}]. Defined by the user in the following format [Ixx Iyy Izz]. Default = ``[]``.
         inertiaProducts (1,:) {mustBeNumeric}       = [0 0 0]               % (`1x3 float vector`) Rotational inertia or mass products of inertia [kg*m^{2}]. Defined by the user in the following format [Ixy Ixz Iyz]. Default = ``[]``.
         initial (1,1) struct                        = struct(...            % (`structure`) Defines the initial displacement of the body.
@@ -67,6 +67,7 @@ classdef bodyClass<handle
             'area',                                 [0 0 0 0 0 0])          % (`structure`)  Defines the viscous quadratic drag forces. Create an array of structures for variable hydrodynamics. First option define ``drag``, (`6x6 float matrix`), Default = ``zeros(6)``. Second option define ``cd``, (`1x6 float vector`), Default = ``[0 0 0 0 0 0]``, and ``area``, (`1x6 float vector`), Default = ``[0 0 0 0 0 0]``.        
         QTFs (1,1) {mustBeInteger}                  = 0                     % (`integer`) Flag for QTFs calculation, Options: 0 (off), 1 (on). Default = ``0``
         paraview (1,1) {mustBeInteger}              = 1;                    % (`integer`) Flag for visualisation in Paraview either, Options: 0 (no) or 1 (yes). Default = ``1``, only called in paraview.
+        useH5(1,1)                                  = true                  % (`boolean`) Flag to use h5 file for hydrodynamic data.
         variableHydro (1,1) struct                  = struct(...            % (`structure`) Defines the variable hydro implementation.
             'option',                               0,...                   % 
             'hydroForceIndexInitial',               1)                      % (`structure`) Defines the variable hydro implementation. ``option`` (`float`) Flag to turn variable hydrodynamics on or off. ``hydroForceIndexInitial`` (`float`) Defines the initial value of the hydroForceIndex, which should correspond to the hydroForce data (cg, cb, volume, water depth, valid cicEndTime, added mass integrated with the body during runtime) and h5File of the body at equilibrium.
@@ -83,7 +84,6 @@ classdef bodyClass<handle
         dofEnd              = []                               % (`integer`) Index the DOF ends for (``body.number``). For WEC bodies this is given in the h5 file, but if not defined in the h5 file, Default = ``(body.number-1)*6+6``.
         dofStart            = []                               % (`integer`) Index the DOF starts for (``body.number``). For WEC bodies this is given in the h5 file, but if not defined in the h5 file, Default = ``(body.number-1)*6+1``.
         hydroData           = struct()                         % (`structure`) A structure array that defines the hydrodynamic data from BEM or user defined.
-        hydroStruct         = struct()                         % (`structure`) A temporary structure array that contains hydroData when it is directly used in the bodyClass constructor.
     end
 
     properties (SetAccess = 'private', GetAccess = 'public')% internal


### PR DESCRIPTION
I know this is already possible using the multiple run condition work flow, but for my work flow that process seemed inconvenient and not very intuitive. See discussion #1410 for more background.

This PR has a small edit to the BodyClass constructor, allowing for either an h5File to be the input (so the old workflow shouldn't be disrupted), or a structure. I've included a quick check on the structure format (mostly just to make sure the structure that BEMIO uses for writing the h5file isn't mistakenly being used) but it might be worth it to add a more robust check.

Additionally I made an edit to the initializeWecSim script to make use of the new capability this constructor enables.

Let me know if you think adding a more detailed check on the structure is worthwhile and if any additional documentation would be helpful.