### PR TITLE
Fix wave generation with phaseSeed in waveClass for PCT

### DIFF
--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -598,7 +598,9 @@ classdef waveClass<handle
             % Sets the irregular wave's random phase
             % used by: :meth:`waveClass.setup`.
             if obj.phaseSeed ~= 0
-                rng(obj.phaseSeed);     % Phase seed = 1,2,3,...,etc
+                s = RandStream('Threefry', 'Seed', 1);  % Global fixed seed
+                s.Substream = obj.phaseSeed;           % Substream based on phaseSeed
+                RandStream.setGlobalStream(s);         % Set globally
             else
                 rng('shuffle');         % Phase seed shuffled
             end


### PR DESCRIPTION
This PR updates the random number generation in `setWavePhase` in the `waveClass` to use `RandStream` with `Substream`, instead of `rng(phaseSeed)`. The change ensures deterministic and reproducible wave elevation profiles across both serial (`wecSim`) and parallel (`wecSimPCT`) simulations when `phaseSeed` is specified. This resolves the issue where parallel runs with the same seed could produce different results due to independent worker streams (see Issue #1329 ). The new approach uses the `Threefry` generator, which supports substreams and is recommended by MathWorks for parallel reproducibility.

This PR can be tested using the MCR example available here: WEC-Sim_Applications/Multiple_Condition_Runs/RM3_MCROPT3 running the attached script. 
[irregularWaveGenerationExample.zip](https://github.com/user-attachments/files/20213653/irregularWaveGenerationExample.zip)


The wave profiles generated with `wecSim` and `wecSimPCT` should be identical when using the same seed value.