### PR TITLE
Refactor badBemioFix_fcn

### DIFF
--- a/docs/theory/theory.rst
+++ b/docs/theory/theory.rst
@@ -279,7 +279,7 @@ equations. In general, a linear system is desired such that:
     \dot{X}_{r} \left( t \right) =
         \mathbf{A_{r}} X_{r} \left( t \right) +
         \mathbf{B_{r}} \mathbf{u} (t);~~X_{r}\left( 0 \right) = 0~~ \nonumber \\
-    \int_{0}^{t} \mathbf{K_{r}} \left( t- \tau \right) d\tau \approx
+    \int_{0}^{t} \mathbf{K_{r}} \left( t- \tau \right) \dot{X} \left( \tau \right) d\tau \approx
         \mathbf{C_{r}} X_{r} \left( t \right) +
         \mathbf{D_{r}} \mathbf{u} \left( t \right)~~
 

--- a/source/functions/BEMIO/cleanBEM.m
+++ b/source/functions/BEMIO/cleanBEM.m
@@ -1,6 +1,12 @@
 function hydro = cleanBEM(hydro, despike)
 % Original author: Dominic D. Forbush
+% 
 % Based on the paper: 
+% Kelly, T., Zabala, I., Peña-Sanchez, Y., Penalba, M., Ringwood, J. V.,
+% Henriques, J. C., & Blanco, J. M. (2022). A post-processing technique for
+% removing ‘irregular frequencies’ and other issues in the results from BEM
+% solvers. International Marine Energy Journal, 5(1), 123–131.
+% https://doi.org/10.36688/imej.5.123-131
 % 
 % This function cleans noisy BEM coefficients (A, B, ex) by:
 % - identifying and removing sharp peaks (IRR effects)

--- a/source/functions/BEMIO/cleanBEM.m
+++ b/source/functions/BEMIO/cleanBEM.m
@@ -129,19 +129,19 @@ if despike.appFilt == 1
         % hydro.ex_ma(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.ex_ma(k,1,:)));
         % hydro.ex_ph(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.ex_ph(k,1,:)));
 
-        if isfield(hydro,'sc_re')
-            hydro.sc_re(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.sc_re(k,1,:)));
-            hydro.sc_im(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.sc_im(k,1,:)));
-            % hydro.sc_ma(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.sc_ma(k,1,:)));
-            % hydro.sc_ph(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.sc_ph(k,1,:)));
-        end
+        % if isfield(hydro,'sc_re')
+        %     hydro.sc_re(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.sc_re(k,1,:)));
+        %     hydro.sc_im(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.sc_im(k,1,:)));
+        %     % hydro.sc_ma(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.sc_ma(k,1,:)));
+        %     % hydro.sc_ph(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.sc_ph(k,1,:)));
+        % end
 
-        if isfield(hydro,'fk_re')
-            hydro.fk_re(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.fk_re(k,1,:)));
-            hydro.fk_im(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.fk_im(k,1,:)));
-            % hydro.fk_ma(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.fk_ma(k,1,:)));
-            % hydro.fk_ph(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.fk_ph(k,1,:)));
-        end
+        % if isfield(hydro,'fk_re')
+        %     hydro.fk_re(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.fk_re(k,1,:)));
+        %     hydro.fk_im(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.fk_im(k,1,:)));
+        %     % hydro.fk_ma(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.fk_ma(k,1,:)));
+        %     % hydro.fk_ph(k,1,:) = filtfilt(despike.Filter.b,despike.Filter.a,squeeze(hydro.fk_ph(k,1,:)));
+        % end
     end
 end
 

--- a/source/functions/BEMIO/cleanBEM.m
+++ b/source/functions/BEMIO/cleanBEM.m
@@ -1,6 +1,7 @@
-function hydro = cleanBEM(hydro, despike)
+ function hydro = cleanBEM(hydro, despike)
 % Original author: Dominic D. Forbush
-% 
+% Contributors: Adam Keester
+
 % Based on the paper: 
 % Kelly, T., Zabala, I., Peña-Sanchez, Y., Penalba, M., Ringwood, J. V.,
 % Henriques, J. C., & Blanco, J. M. (2022). A post-processing technique for

--- a/source/functions/BEMIO/cleanBEM.m
+++ b/source/functions/BEMIO/cleanBEM.m
@@ -86,6 +86,8 @@ if isempty(despike) % if the third argument is empty will use some default value
     despike.B.MinPeakDistance = 3;
     despike.ExRe.MinPeakDistance = 3;
     despike.ExIm.MinPeakDistance = 3;
+
+    % the b and a inputs to MATLAB's filtfilt(b,a,x) function
     despike.Filter.b = 0.02008336556421123561544384017452102853 .* [1 2 1];
     despike.Filter.a = [1 -1.561018075800718163392843962355982512236 0.641351538057563175243558362126350402832];
 end

--- a/source/functions/BEMIO/cleanBEM.m
+++ b/source/functions/BEMIO/cleanBEM.m
@@ -57,7 +57,6 @@ function hydro = cleanBEM(hydro, despike)
 
 %% de-spiking parameters
 % maxPeakWidth is not recommended however as it has unexpected behavior
-
 if isempty(despike) % if the third argument is empty will use some default values
     despike = struct();
     despike.negThresh = 1e-3; % the threshold below which negative damping will be removed
@@ -89,7 +88,9 @@ end
 % rename so that original H5 is not overwritten
 hydro.file = [hydro.file '_clean'];
 
-% forcibly remove IRF values so that the structure is self-consistent
+% The IRFs and state-space fields need to be recalculated based on the
+% cleaned coefficients. Forcibly remove these fields here so that the
+% structure is self-consistent
 fieldsToRemove = {'ex_K','ex_t','ex_w','ra_K','ra_t','ra_w',...
     'ss_A','ss_B','ss_C','ss_D','ss_K','ss_conv','ss_R2','ss_O'};
 for i = 1:length(fieldsToRemove)
@@ -160,7 +161,10 @@ end
 
 %% Functions
 function outData = peakSmoothing(data, w, despike, n)
-    w = w(:); % force w formatting
+    % force consistent input formatting
+    w = w(:);
+    data = data(:);
+
     for it = 1:n
         %%% There is a "maxPeakWidth" argument: this does not work as
         %%% the developer intends and is not recommended for use.

--- a/source/functions/BEMIO/cleanBEM.m
+++ b/source/functions/BEMIO/cleanBEM.m
@@ -1,5 +1,5 @@
-function hydro = badBemioFix_fcn(hydro, despike)
-% Oirignal author: Dominic D. Forbush
+function hydro = cleanBEM(hydro, despike)
+% Original author: Dominic D. Forbush
 % Based on the paper: 
 % 
 % This function cleans noisy BEM coefficients (A, B, ex) by:
@@ -35,7 +35,7 @@ function hydro = badBemioFix_fcn(hydro, despike)
 % Example 1:
 % >> hydro = readWAMIT(hydro, ...);
 % >> hydro = combineBEM(hydro);
-% >> hydro = badBemioFix_fcn(hydro, despike); 
+% >> hydro = cleanBEM(hydro, despike); 
 % >> hydro = radiationIRF(hydro, ...);
 % >> hydro = radiationIRFSS(hydro, ...);
 % >> hydro = excitationIRF(hydro, ...);
@@ -48,7 +48,7 @@ function hydro = badBemioFix_fcn(hydro, despike)
 % >> hydro = radiationIRF(hydro, ...);
 % >> hydro = radiationIRFSS(hydro, ...);
 % >> hydro = excitationIRF(hydro, ...);
-% >> hydro_clean = badBemioFix_fcn(hydro, despike); 
+% >> hydro_clean = cleanBEM(hydro, despike); 
 % >> hydro_clean = radiationIRF(hydro_clean, ...);
 % >> hydro_clean = radiationIRFSS(hydro_clean, ...);
 % >> hydro_clean = excitationIRF(hydro_clean, ...);

--- a/source/functions/BEMIO/radiationIRF.m
+++ b/source/functions/BEMIO/radiationIRF.m
@@ -68,7 +68,7 @@ end
 % Calculate the infinite frequency added mass
 ra_Ainf_temp = zeros(length(hydro.w),1);                                    %Initialize the variable
 [~,F] = size(hydro);                                                        %Last data set in
-if isempty(hydro.Ainf) == 1 || isfield(hydro,'Ainf') == 0 || strcmp(hydro(F).code,'WAMIT')==0
+if isempty(hydro.Ainf) || ~isfield(hydro,'Ainf') || ~strcmp(hydro(F).code,'WAMIT')
     for i = 1:sum(hydro.dof)
         for j = 1:sum(hydro.dof)
             ra_A            = interp1(hydro.w,squeeze(hydro.A(i,j,:)),w);


### PR DESCRIPTION
This PR refactors `badBemioFix_fcn`:
- renames function to `cleanBEM`
- modularizes - the peak smoothing is turned into a single function that is used for all hydro coefficients (A, B, Fex).
- simplifies the interpolation to use the built-in `interp1` for consistency and ease of changing the interpolation method
 - aligns the usage of the function with the rest of BEMIO
    - This is now a standalone function that can be called with any pre-existing hydro structure and it does not read in coefficients on its own
    - IRF and SS coefficients are removed and must be recreated after using this function to fix A, B, Fex
    - IRF and SS function calls are not repeated within the cleaning function, saving time
 - reorganizes the despike structure to fit the function-based method within `cleanBEM`

and fixes a couple bugs:
- the peak smoothing loop for added mass and damping only took the last value and did not iterate from 1:deSpike.N
-  the negative peak finder for imaginary excitation force component was set to "-.1" not "-1."

To compare the largely identical results after the refactor but before a few bug fixes, look at commit 381f8ba

TODO:
- [x] find the citation that this function was based on
- [x] upload comparison script and some sample data