### PR TITLE
Update variable mass implementation and add documentation

### DIFF
--- a/docs/_include/variable_hydro.rst
+++ b/docs/_include/variable_hydro.rst
@@ -72,7 +72,8 @@ every body in a simulation. To implement variable hydrodynamics for a given body
 
     If no mass vector is specified but ``body(1).mass`` is set to equilibrium, the data from H5 
     files will be used to calculate the variable mass based on displaced volume and water density. 
-    However, the inertia vector will still need to be specified or else it will be assumed constant.
+    However, the full inertia vector (``body(1).variableHydro.inertia``) will still need to be 
+    specified or else it will be assumed to be constant and equal to ``body(1).inertia``.
 
 2. Enable Variable Hydrodynamics
     Set the ``body.variableHydro.option`` flag to enable variable hydrodynamics:

--- a/docs/_include/variable_hydro.rst
+++ b/docs/_include/variable_hydro.rst
@@ -63,7 +63,16 @@ every body in a simulation. To implement variable hydrodynamics for a given body
         ``body(1) = bodyClass({'H5FILE_1.h5','H5FILE_2.h5','H5FILE_3.h5','H5FILE_4.h5','H5FILE_5.h5');``
 
     If only one H5 file is used to initialize a body object, variable hydrodynamics
-    will not be used, regardless of the ``option`` flag below.
+    will not be used, regardless of the ``option`` flag below. 
+
+    For variable mass cases, a vector can also be used for the variable hydrodynamics mass, 
+    inertia, and inertia products:
+
+        ``body(1).variableHydro.mass = [mass1, mass2, mass3, mass4, mass5];``
+
+    If no mass vector is specified but ``body(1).mass`` is set to equilibrium, the data from H5 
+    files will be used to calculate the variable mass based on displaced volume and water density. 
+    However, the inertia vector will still need to be specified or else it will be assumed constant.
 
 2. Enable Variable Hydrodynamics
     Set the ``body.variableHydro.option`` flag to enable variable hydrodynamics:

--- a/docs/user/applications.rst
+++ b/docs/user/applications.rst
@@ -141,8 +141,8 @@ This geometry is a special case with a large DOF in which different WEC bodies c
 Variable Hydrodynamics
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Example demonstrating WEC-Sim's variable hydrodynamics feature by comparing it to the passive yaw implementation.
-
+The first example demonstrates WEC-Sim's variable hydrodynamics feature by comparing it to the passive yaw implementation. 
+The second case provides an example for variable mass in which the draft, mass, and center of gravity change during the simulation.
 
 Visualization Markers
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/user/applications.rst
+++ b/docs/user/applications.rst
@@ -141,8 +141,8 @@ This geometry is a special case with a large DOF in which different WEC bodies c
 Variable Hydrodynamics
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The first example demonstrates WEC-Sim's variable hydrodynamics feature by comparing it to the passive yaw implementation. 
-The second case provides an example for variable mass in which the draft, mass, and center of gravity change during the simulation.
+The Variable_Hydro/Passive_Yaw case demonstrates WEC-Sim's variable hydrodynamics feature by comparing it to the passive yaw implementation. 
+The Variable_Hydro/Variable_Mass case provides an example for variable mass in which the draft, mass, and center of gravity change during the simulation.
 
 Visualization Markers
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/source/objects/bodyClass.m
+++ b/source/objects/bodyClass.m
@@ -576,23 +576,34 @@ classdef bodyClass<handle
                                           obj.hydroForce.(hfName).fAddedMass(4,6+(iBod-1)*6) ...
                                           obj.hydroForce.(hfName).fAddedMass(5,6+(iBod-1)*6)];
                     
-                    if isempty(obj.variableHydro.mass)
+                    if ~isempty(obj.variableHydro.mass)
+                        % Setting variable hydro mass properties according to inputs.
+                        assert(length(obj.variableHydro.mass) == length(obj.hydroData),['For variable mass, ' ...
+                            'the mass vector should be the same length as the hydrodata (h5) vector.'])
+                        obj.hydroForce.(hfName).mass = obj.variableHydro.mass(iH);
+                        obj.hydroForce.(hfName).adjustedMass = obj.variableHydro.mass(iH) + adjMass;
+                        obj.hydroForce.(hfName).adjustedInertia = obj.variableHydro.inertia(iH,:) + adjFAddedMass(4:6)';
+                        if isempty(obj.variableHydro.inertiaProducts)
+                            warning('Variable hydro inertia products are not set. Setting to zero by default.')
+                            obj.variableHydro.inertiaProducts(iH,:) = [0 0 0];
+                        end
+                        obj.hydroForce.(hfName).adjustedInertiaProducts = obj.variableHydro.inertiaProducts + adjInertiaProducts;
+                    elseif strcmp(obj.massCalcMethod, 'equilibrium') && ~isempty(obj.variableHydro.inertia)
+                        % Setting variable hydro mass properties according to hydrostatic equilibrium.
+                        obj.hydroForce.(hfName).mass = obj.hydroData(iH).properties.volume*rho;
+                        obj.hydroForce.(hfName).adjustedMass = obj.hydroData(iH).properties.volume*rho + adjMass;
+                        obj.hydroForce.(hfName).adjustedInertia = obj.variableHydro.inertia(iH,:) + adjFAddedMass(4:6)';
+                        if isempty(obj.variableHydro.inertiaProducts)
+                            warning('Variable hydro inertia products are not set. Setting to zero by default.')
+                            obj.variableHydro.inertiaProducts(iH,:) = [0 0 0];
+                        end
+                        obj.hydroForce.(hfName).adjustedInertiaProducts = obj.variableHydro.inertiaProducts + adjInertiaProducts;
+                    else
+                        % Setting variable hydro mass as constant.
                         obj.hydroForce.(hfName).mass = obj.mass;
                         obj.hydroForce.(hfName).adjustedMass = obj.mass + adjMass;
                         obj.hydroForce.(hfName).adjustedInertia = obj.inertia + adjFAddedMass(4:6)';
                         obj.hydroForce.(hfName).adjustedInertiaProducts = obj.inertiaProducts + adjInertiaProducts;
-                    else
-                        if strcmp(obj.massCalcMethod, 'equilibrium')
-                            obj.hydroForce.(hfName).mass = obj.hydroData(iH).properties.volume*rho;
-                            obj.hydroForce.(hfName).adjustedMass = obj.hydroData(iH).properties.volume*rho + adjMass;
-                            obj.hydroForce.(hfName).adjustedInertia = obj.variableHydro.inertia(iH,:) + adjFAddedMass(4:6)';
-                            obj.hydroForce.(hfName).adjustedInertiaProducts = obj.variableHydro.inertiaProducts + adjInertiaProducts;
-                        else
-                            obj.hydroForce.(hfName).mass = obj.variableHydro.mass(iH);
-                            obj.hydroForce.(hfName).adjustedMass = obj.variableHydro.mass(iH) + adjMass;
-                            obj.hydroForce.(hfName).adjustedInertia = obj.variableHydro.inertia(iH,:) + adjFAddedMass(4:6)';
-                            obj.hydroForce.(hfName).adjustedInertiaProducts = obj.variableHydro.inertiaProducts + adjInertiaProducts;
-                        end
                     end
 
                     obj.hydroForce.(hfName).fAddedMass(1,1+(iBod-1)*6) = obj.hydroForce.(hfName).fAddedMass(1,1+(iBod-1)*6) - adjMass;
@@ -624,23 +635,35 @@ classdef bodyClass<handle
                     adjInertiaProducts = [obj.hydroForce.(hfName).fAddedMass(4,5) ...
                                           obj.hydroForce.(hfName).fAddedMass(4,6) ...
                                           obj.hydroForce.(hfName).fAddedMass(5,6)];
-                    if isempty(obj.variableHydro.mass)
+                    
+                    if ~isempty(obj.variableHydro.mass)
+                        % Setting variable hydro mass properties according to inputs.
+                        assert(length(obj.variableHydro.mass) == length(obj.hydroData),['For variable mass, ' ...
+                            'the mass vector should be the same length as the hydrodata (h5) vector.'])
+                        obj.hydroForce.(hfName).mass = obj.variableHydro.mass(iH);
+                        obj.hydroForce.(hfName).adjustedMass = obj.variableHydro.mass(iH) + adjMass;
+                        obj.hydroForce.(hfName).adjustedInertia = obj.variableHydro.inertia(iH,:) + adjFAddedMass(4:6)';
+                        if isempty(obj.variableHydro.inertiaProducts)
+                            warning('Variable hydro inertia products are not set. Setting to zero by default.')
+                            obj.variableHydro.inertiaProducts(iH,:) = [0 0 0];
+                        end
+                        obj.hydroForce.(hfName).adjustedInertiaProducts = obj.variableHydro.inertiaProducts + adjInertiaProducts;
+                    elseif strcmp(obj.massCalcMethod, 'equilibrium') && ~isempty(obj.variableHydro.inertia)
+                        % Setting variable hydro mass properties according to hydrostatic equilibrium.
+                        obj.hydroForce.(hfName).mass = obj.hydroData(iH).properties.volume*rho;
+                        obj.hydroForce.(hfName).adjustedMass = obj.hydroData(iH).properties.volume*rho + adjMass;
+                        obj.hydroForce.(hfName).adjustedInertia = obj.variableHydro.inertia(iH,:) + adjFAddedMass(4:6)';
+                        if isempty(obj.variableHydro.inertiaProducts)
+                            warning('Variable hydro inertia products are not set. Setting to zero by default.')
+                            obj.variableHydro.inertiaProducts(iH,:) = [0 0 0];
+                        end
+                        obj.hydroForce.(hfName).adjustedInertiaProducts = obj.variableHydro.inertiaProducts + adjInertiaProducts;
+                    else
+                        % Setting variable hydro mass as constant.
                         obj.hydroForce.(hfName).mass = obj.mass;
                         obj.hydroForce.(hfName).adjustedMass = obj.mass + adjMass;
                         obj.hydroForce.(hfName).adjustedInertia = obj.inertia + adjFAddedMass(4:6)';
                         obj.hydroForce.(hfName).adjustedInertiaProducts = obj.inertiaProducts + adjInertiaProducts;
-                    else
-                        if strcmp(obj.massCalcMethod, 'equilibrium')
-                            obj.hydroForce.(hfName).mass = obj.hydroData(iH).properties.volume*rho;
-                            obj.hydroForce.(hfName).adjustedMass = obj.hydroData(iH).properties.volume*rho + adjMass;
-                            obj.hydroForce.(hfName).adjustedInertia = obj.variableHydro.inertia(iH,:) + adjFAddedMass(4:6)';
-                            obj.hydroForce.(hfName).adjustedInertiaProducts = obj.inertiaProducts + adjInertiaProducts;
-                        else
-                            obj.hydroForce.(hfName).mass = obj.variableHydro.mass(iH);
-                            obj.hydroForce.(hfName).adjustedMass = obj.variableHydro.mass(iH) + adjMass;
-                            obj.hydroForce.(hfName).adjustedInertia = obj.variableHydro.inertia(iH,:) + adjFAddedMass(4:6)';
-                            obj.hydroForce.(hfName).adjustedInertiaProducts = obj.inertiaProducts + adjInertiaProducts;
-                        end
                     end
 
                     obj.hydroForce.(hfName).fAddedMass(1,1) = obj.hydroForce.(hfName).fAddedMass(1,1) - adjMass;


### PR DESCRIPTION
This PR updates the variable mass to follow the workflow:
1. Use variable mass inputs from user.
2. If no variable mass input but variable inertia is present in the input file, assume equilibrium and use the provided variable inertia.
3. If no variable mass or inertia is present, use the specified body mass and inertia for all variable hydro cases.

I also added some documentation for the updated variable mass example ([PR 90 on Applications](https://github.com/WEC-Sim/WEC-Sim_Applications/pull/90)).