### PR TITLE
`waveClass` Constructor Improvements

### DIFF
--- a/source/objects/+internal/waveType.m
+++ b/source/objects/+internal/waveType.m
@@ -7,6 +7,7 @@ classdef waveType
         regularCIC
         irregular
         spectrumImport
+        spectrumImportFullDir
         elevationImport
     end
 

--- a/source/objects/+internal/waveType.m
+++ b/source/objects/+internal/waveType.m
@@ -1,0 +1,13 @@
+classdef waveType
+
+    enumeration
+        noWave
+        noWaveCIC
+        regular
+        regularCIC
+        irregular
+        spectrumImport
+        elevationImport
+    end
+
+end

--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -118,6 +118,10 @@ classdef waveClass<handle
             %         waveClass object
             %
 
+            arguments
+                type (1,1) internal.waveType
+            end
+
             obj.type = type;
             switch obj.type
                 case {'noWave'}         % No Waves with Constant Hydrodynamic Coefficients
@@ -164,12 +168,6 @@ classdef waveClass<handle
             mustBeInRange(obj.direction,-360, 360)
             mustBeInRange(obj.spread,0, 1)
 
-            % check wave type
-            types = {'noWave', 'noWaveCIC', 'regular', 'regularCIC', 'irregular', 'spectrumImport','spectrumImportFullDir', 'elevationImport'};
-            if sum(strcmp(types,obj.type)) ~= 1
-                error(['Unexpected wave environment type setting, choose from: ' ...
-                    '"noWave", "noWaveCIC", "regular", "regularCIC", "irregular", "spectrumImport", "spectrumImportFullDir", and "elevationImport".'])
-            end
             % check 'waves.bem' fields
             if length(fieldnames(obj.bem)) ~=4
                 error(['Unrecognized method, property, or field for class "waveClass", ' ...


### PR DESCRIPTION
## Summary
Improves the `waveClass` constructor by replacing string-based type validation with a MATLAB enumeration. This implementation suggests the different wave types to users as they construct `waveClass` objects, and reduces boilerplate code.

## Changes
- **Modified**: `source/objects/waveClass.m` - Updated constructor to use `arguments` block with `internal.waveType` validation
- **Added**: `source/objects/+internal/waveType.m` - New enumeration defining all valid wave types

## Benefits
- **Type Safety**: Compile-time validation prevents invalid wave type strings
- **Better IntelliSense**: IDE can provide autocomplete for valid wave types  
- **Future-proof**: Easy to add new wave types by extending the enumeration
- **Backward Compatible**: Existing functionality unchanged
