### PR TITLE
[BUG] Fix paraview outputs for new wave types

### DIFF
--- a/source/functions/paraview/paraviewVisualization.m
+++ b/source/functions/paraview/paraviewVisualization.m
@@ -61,7 +61,7 @@ if simu.paraview.option == 1
         end
     end
     % all
-    writeParaviewResponse(bodies, TimeBodyParav, modelName, datestr(simu.date), waves.type, simu.numMoorDyn, simu.paraview.path);
+    writeParaviewResponse(bodies, TimeBodyParav, modelName, datestr(simu.date), char(waves.type), simu.numMoorDyn, simu.paraview.path);
     clear bodies fid filename
 end
 clear body*_hspressure_out body*_wavenonlinearpressure_out body*_wavelinearpressure_out  hspressure wpressurenl wpressurel cellareas bodyname NewTimeParaview PositionBodyParav TimeBodyParav vtkbodiesii

--- a/source/functions/paraview/writeParaviewWave.m
+++ b/source/functions/paraview/writeParaviewWave.m
@@ -53,7 +53,7 @@ for it = 1:length(t)
     fprintf(fid, '<?xml version="1.0"?>\n');
     fprintf(fid, ['<!-- WEC-Sim Visualization using ParaView -->\n']);
     fprintf(fid, ['<!--   model: ' model ' - ran on ' simdate ' -->\n']);
-    fprintf(fid, ['<!--   wave:  ' waves.type ' -->\n']);
+    fprintf(fid, ['<!--   wave:  ' char(waves.type) ' -->\n']);
     fprintf(fid, ['<!--   time:  ' num2str(TimeBodyParav(it)) ' -->\n']);
     fprintf(fid, '<VTKFile type="PolyData" version="0.1">\n');
     fprintf(fid, '  <PolyData>\n');


### PR DESCRIPTION
With PR #1515, the wave type is changed slightly from a string to an enumerator. When outputting to Paraview, this means that the wave type needs to be converted to a character array before printing.