### PR TITLE
Nonlinear FK force big Fix introduced in v6.1.2

### DIFF
--- a/source/functions/simulink/model/nonFKForce.m
+++ b/source/functions/simulink/model/nonFKForce.m
@@ -34,8 +34,8 @@ tnorm = rotateXYZ(tnorm,[0 0 1],x(6));
 av = tnorm .* [area area area];
 
 % Calculate the free surface
-wpMeanFS = pDis(centerMeanFS,0,direction,spread,AH,w,dw,wDepth,deepWater,t,k,phaseRand,typeNum,rho,g);
-wp = pDis(center,elv,direction,spread,AH,w,dw,wDepth,deepWater,t,k,phaseRand,typeNum,rho,g);
+wpMeanFS = pDis(centerMeanFS,elv,0,direction,spread,AH,w,dw,wDepth,deepWater,t,k,phaseRand,typeNum,rho,g);
+wp = pDis(center,elv,1,direction,spread,AH,w,dw,wDepth,deepWater,t,k,phaseRand,typeNum,rho,g);
 
 % Calculate forces
 f_linear   =FK(centerMeanFS,       cg,avMeanFS,wpMeanFS);
@@ -43,7 +43,7 @@ f_nonLinear=FK(center      ,x(1:3)+cg,av      ,wp      );
 f = f_nonLinear-f_linear;
 end
 
-function f=pDis(center,elv,direction,spread,AH,w,dw,wDepth,deepWater,t,k,phaseRand,typeNum,rho,g)
+function f=pDis(center,elv,elvCorr,direction,spread,AH,w,dw,wDepth,deepWater,t,k,phaseRand,typeNum,rho,g)
 % Function to calculate pressure distribution
 f = zeros(length(center(:,3)),1);
 fk= zeros(length(center(:,3)),1);
@@ -52,10 +52,10 @@ if typeNum <10
 elseif typeNum <20
     f = rho.*g.*elv;
     if deepWater == 0
-        z=(center(:,3)-elv).*wDepth./(wDepth+elv);
+        z=(center(:,3)-elv*elvCorr).*wDepth./(wDepth+elv*elvCorr);
         f = f.*(cosh(k(1).*(z+wDepth))./cosh(k(1)*wDepth));
     else
-        z=(center(:,3)-elv);
+        z=(center(:,3)-elv*elvCorr);
         f = f.*exp(k(1).*z);
     end
 elseif typeNum <30
@@ -65,11 +65,11 @@ elseif typeNum <30
         X = cx*cos(direction(kk)*pi/180) + cy*sin(direction(kk)*pi/180);
         for i=1:length(AH)
             if deepWater == 0 && wDepth <= 0.5*pi/k(i)
-                z=(center(:,3)-elv).*wDepth./(wDepth+elv);
+                z=(center(:,3)-elv*elvCorr).*wDepth./(wDepth+elv*elvCorr);
                 f_tmp = rho.*g.*sqrt(AH(i)*dw(i)).*cos(k(i).*X-w(i)*t-phaseRand(i,kk));
                 fk(:,1) = fk(:,1) + spread(kk) .* f_tmp.*(cosh(k(i).*(z+wDepth))./cosh(k(i).*wDepth));
             else
-                z=(center(:,3)-elv);
+                z=(center(:,3)-elv*elvCorr);
                 f_tmp = rho.*g.*sqrt(AH(i)*dw(i)).*cos(k(i).*X-w(i)*t-phaseRand(i));
                 fk(:,1) = fk(:,1) + spread(kk) .*f_tmp.*exp(k(i).*z);
             end


### PR DESCRIPTION
The calculation of the nonlinear Froude–Krylov (FK) force requires first computing both the linear and nonlinear forces, then subtracting the linear from the nonlinear. A formula for the wave elevation that accounts for wave directionality and spreading was recently added a [previous commit ](https://github.com/WEC-Sim/WEC-Sim/commit/1f559e9dff3595c2be7eef7212e0568c6652d6f4) in versuon 6.1.2, but this change affected the linear FK force calculation, leading to exaggerated responses and excitation forces. 

This PR is related to Issue #1485 and Issue #1457 

