### PR TITLE
Fix spread with nonlinear hydro

### DIFF
--- a/source/functions/simulink/model/nonFKForce.m
+++ b/source/functions/simulink/model/nonFKForce.m
@@ -66,12 +66,12 @@ elseif typeNum <30
         for i=1:length(AH)
             if deepWater == 0 && wDepth <= 0.5*pi/k(i)
                 z=(center(:,3)-elv*elvCorr).*wDepth./(wDepth+elv*elvCorr);
-                f_tmp = rho.*g.*sqrt(AH(i)*dw(i)).*cos(k(i).*X-w(i)*t-phaseRand(i,kk));
-                fk(:,1) = fk(:,1) + spread(kk) .* f_tmp.*(cosh(k(i).*(z+wDepth))./cosh(k(i).*wDepth));
+                f_tmp = rho.*g.*sqrt(spread(kk).*AH(i)*dw(i)).*cos(k(i).*X-w(i)*t-phaseRand(i,kk));
+                fk(:,1) = fk(:,1) + f_tmp.*(cosh(k(i).*(z+wDepth))./cosh(k(i).*wDepth));
             else
                 z=(center(:,3)-elv*elvCorr);
-                f_tmp = rho.*g.*sqrt(AH(i)*dw(i)).*cos(k(i).*X-w(i)*t-phaseRand(i));
-                fk(:,1) = fk(:,1) + spread(kk) .*f_tmp.*exp(k(i).*z);
+                f_tmp = rho.*g.*sqrt(spread(kk).*AH(i)*dw(i)).*cos(k(i).*X-w(i)*t-phaseRand(i));
+                fk(:,1) = fk(:,1) + f_tmp.*exp(k(i).*z);
             end
         end
         f=fk+f;


### PR DESCRIPTION
This PR fixes the nonlinear hydro calculation for cases with wave spreading. The spread term is moved to under the square root to be consistent with our [documentation](https://wec-sim.github.io/WEC-Sim/main/theory/theory.html#frequency-varying-direction-and-spread) and the other irregular excitation functions. 

I tested this to make sure everything runs, but I did not get a chance to test a nonlinear case with spread. A quick test would be to run the OSWEC case with nonlinear hydrodynamics and an irregular wave with spread in a few directions. Then, compare the result to the same irregular wave without spread. The result should show increased excitation for the case without spread (difference depends on the spread values).