### PR TITLE
Pushes PR #1544 into dev: Fix documentation typos and broken citaions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,10 +63,12 @@ napoleon_use_param = True
 napoleon_use_rtype = True
 
 # sphinxcontrib.bibtex settings
-bibtex_bibfiles = ['refs/WEC-Sim_Adv_Features.bib',
-                   'refs/WEC-Sim_Theory.bib',
-                   'refs/WEC-Sim_Tutorials.bib',
-                   'most/MOST.bib']
+bibtex_bibfiles = [
+    str(docs_source_dir / "refs" / "WEC-Sim_Adv_Features.bib"),
+    str(docs_source_dir / "refs" / "WEC-Sim_Theory.bib"),
+    str(docs_source_dir / "refs" / "WEC-Sim_Tutorials.bib"),
+    str(docs_source_dir / "most" / "MOST.bib"),
+]
 
 # sphinxcontrib.matlab settings
 primary_domain = 'mat'

--- a/docs/theory/theory.rst
+++ b/docs/theory/theory.rst
@@ -206,7 +206,7 @@ The mean drift force is combined with the excitation force in the response class
 .. ACTION: Add QTF documentation here
 
 .. Note::
-    Currently, WEC-Sim only supports mean drift coefficients and QTF from WAMIT.
+    Currently, WEC-Sim supports mean drift coefficients and QTF from WAMIT and NEMOH.
 
 .. _cic_theory:
 
@@ -545,7 +545,7 @@ A more general description of a wave field can be expressed
     
 where :math:`D(\omega,\theta)` indicates that the directional components of a wave can also
 vary with frequency. The total energy in the directional spectrum must be the same at each frequency
-as the total energy in the one-dimensional spectrum. At each frequency,:math:`D(\theta)` is often parameterized by an
+as the total energy in the one-dimensional spectrum. At each frequency, :math:`D(\theta)` is often parameterized by an
 analytical distribution about a mean value, called a spreading function. The default spreading function
 used by WEC-Sim is a Gaussian defined by a mean :math:`\theta` and a standard deviation `\psi`.
 


### PR DESCRIPTION
This PR ports the changes from [#1544](https://github.com/WEC-Sim/WEC-Sim/pull/1544), which was merged into main, into the dev branch.

Corrected typos in the documentation and fixed broken citations in the theory guide
