### PR TITLE
Fix deep water flag bug

### DIFF
--- a/source/objects/waveClass.m
+++ b/source/objects/waveClass.m
@@ -649,6 +649,12 @@ classdef waveClass<handle
                 if ~isempty(bemWaterDepth)
                     warning('Because water depth is specified in the wecSimInputFile, the water depth from the BEM data is ignored')
                 end
+                if isinf(obj.waterDepth)
+                    obj.deepWater = 1;
+                    obj.waterDepth = 200;
+                else
+                    obj.deepWater = 0;
+                end
             end
         end
 


### PR DESCRIPTION
When setting the water depth manually in the `wecSimInputFile.m`, the deep water flag is not defined which leads to an error in the Simulink model. Discovered in issue #1578. This PR fixes this bug by defining `waves.deepWater` for all cases. 