### PR TITLE
Update degenerate mass documentation

### DIFF
--- a/docs/user/applications.rst
+++ b/docs/user/applications.rst
@@ -39,7 +39,9 @@ Desalination
 ^^^^^^^^^^^^
 
 Example using WEC-Sim for desalination based on the :ref:`OSWEC <user-tutorials-oswec>` 
-geometry. Note the dependency on SimScape Fluids to run this desalination case. 
+geometry. See :ref:`user-troubleshooting` for information on degenerate mass 
+errors which necessitate an inertia block between the constraint and PTO.
+Note the dependency on SimScape Fluids to run this desalination case. 
 
 Free Decay
 ^^^^^^^^^^

--- a/docs/user/troubleshooting.rst
+++ b/docs/user/troubleshooting.rst
@@ -207,7 +207,9 @@ Simulink cannot reconcile the forcing and motion between these series joints wit
 	... Joint has a degenerate mass distribution on its base/follower side.
 
 **Solution:**
-Add an insignificantly small mass between the two joints (e.g. ``Simulink Library/Simscape/Multibody/Body Elements/Inertia``) .
+Add an insignificantly small mass between the two joints (e.g. ``Simulink Library/Simscape/Multibody/Body Elements/Inertia``).
+For most cases, the mass will only need to be added on the follower side of the PTO block. 
+See the `desalination WEC-Sim Applications case <https://github.com/WEC-Sim/WEC-Sim_Applications/tree/main/Desalination>`_ for an example with an added inertia block to resolve degenerate mass errors.
 Alternatively, create a new PTO or constraint with one of the many joints available in the 
 Simscape Multibody Joints library if special degrees of freedom are required.
 


### PR DESCRIPTION
This PR updates the documentation for the degenerate mass to add a bit more detail and reference the desalination example case. There is no one-size-fits-all solution to the degenerate mass errors, but issues can generally be fixed by adding a small mass to the follower side of the PTO. After reviewing the degenerate mass errors and investigating the [examples developed by Dom](https://github.com/dforbush2/DegenMassIssues), I feel that the desalination applications case provides a sufficient example of how to resolve degenerate mass errors.

See also updates to desalination case to restore the broken library link in [WEC-Sim Applications PR#102](https://github.com/WEC-Sim/WEC-Sim_Applications/pull/102).