### PR TITLE
Prevent problem with leading spaces in the MoorDyn output file header line

### DIFF
--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -364,7 +364,7 @@ classdef responseClass<handle
             fileRootPath = char(inputStrings(1));
             filename = append(fileRootPath,'.out');
             fid = fopen(filename, 'r');
-            header = strsplit(fgetl(fid));
+            header = strsplit(strtrim(fgetl(fid)));
             data = dlmread(filename,'',1,0);
             tmp = size(data);
             ncol = tmp(2);clear tmp


### PR DESCRIPTION
Ran into a problem where the leading spaces in the MoorDyn output file header line turning into an empty column name. The problem is fixed by simply removing the leading spaces.