### PR TITLE
Disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+# disable blank issues
+blank_issues_enabled: false
+
+# link to documentation
+documentation_link:
+  - name: Review WEC-Sim documentation
+    url: https://wec-sim.github.io/WEC-Sim/main/index.html
+    about: Please review documemntation and previous issues before asking questions.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@
 blank_issues_enabled: false
 
 # link to documentation
-documentation_link:
+contact_links:
   - name: Review WEC-Sim documentation
     url: https://wec-sim.github.io/WEC-Sim/main/index.html
-    about: Please review documemntation and previous issues before asking questions.
+    about: Please review documentation and previous issues before asking questions.


### PR DESCRIPTION
I noticed that a lot of users are recently using the blank issue template. I added a config file which disables this option and links to documentation. I think this will help encourage users to provide more info when opening issues.