### PR TITLE
Update Capytaine examples for v3

### DIFF
--- a/examples/BEMIO/CAPYTAINE/cubes/main.py
+++ b/examples/BEMIO/CAPYTAINE/cubes/main.py
@@ -21,7 +21,7 @@ r_cube_body.inertia_matrix = r_cube_body.compute_rigid_body_inertia()
 r_cube_body.hydrostatic_stiffness = r_cube_body.immersed_part().compute_hydrostatic_stiffness()
 
 t_cube_mesh_file = os.path.join(input_data_dir, "t_cube.dat")
-t_cube_mesh = cpt.load_mesh(t_cube_mesh_file, file_format="dat")
+t_cube_mesh = cpt.load_mesh(t_cube_mesh_file, file_format="nemoh")
 t_cube_body = cpt.FloatingBody(
     mesh=t_cube_mesh,
     lid_mesh=t_cube_mesh.generate_lid(),


### PR DESCRIPTION
I've been testing the development version of Capytaine before the release of version 3.

This PR is the only thing I had to update to make the examples in the BEMIO directory compatible with the upcoming version 3 of Capytaine. The examples remains also compatible with 2.3.1, and there is no need to update the large datasets computed with 2.3.1.

In the future, the examples could be updated to make use v3-only features for multibody hydrostatics, but for now keeping examples compatible with 2.3.1 might be reasonable.